### PR TITLE
feat: 칭찬 메세지 생성 (물 주기) API 설계 #12

### DIFF
--- a/src/main/java/com/yapp/betree/controller/MessageController.java
+++ b/src/main/java/com/yapp/betree/controller/MessageController.java
@@ -6,6 +6,7 @@ import com.yapp.betree.service.MessageService;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -48,7 +49,7 @@ public class MessageController {
 
         messageService.createMessage(userId, requestDto);
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     /**
@@ -72,14 +73,14 @@ public class MessageController {
      * @param messageIdList 선택한 메세지 ID List
      */
     @PutMapping("/api/messages/opening")
-    public ResponseEntity<Void> openingMessage(@RequestParam Long userId,
+    public ResponseEntity<Object> openingMessage(@RequestParam Long userId,
                                                @RequestParam List<Long> messageIdList) throws Exception {
 
         log.info("[messageIdList] : {}", messageIdList);
 
         messageService.updateMessageOpening(userId, messageIdList);
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
 }

--- a/src/main/java/com/yapp/betree/controller/MessageController.java
+++ b/src/main/java/com/yapp/betree/controller/MessageController.java
@@ -1,6 +1,7 @@
 package com.yapp.betree.controller;
 
 import com.yapp.betree.dto.request.MessageRequestDto;
+import com.yapp.betree.dto.response.MessagePageResponseDto;
 import com.yapp.betree.service.MessageService;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -22,6 +24,7 @@ public class MessageController {
 
     /**
      * 칭찬 메세지 생성 (물 주기)
+     *
      * @param data       HTTP header
      * @param requestDto messageRequestDto
      */
@@ -47,4 +50,36 @@ public class MessageController {
 
         return ResponseEntity.noContent().build();
     }
+
+    /**
+     * 메세지함 목록 조회
+     *
+     * @param userId
+     */
+    @GetMapping("/api/messages")
+    public ResponseEntity<MessagePageResponseDto> getMessageList(@RequestParam Long userId,
+                                                                       @RequestParam int page) {
+
+        log.info("[userId] : {}", userId);
+
+        return ResponseEntity.ok(messageService.getMessageList(userId, page));
+    }
+
+    /**
+     * 메세지 공개 여부 설정 (열매 맺기)
+     *
+     * @param userId
+     * @param messageIdList 선택한 메세지 ID List
+     */
+    @PutMapping("/api/messages/opening")
+    public ResponseEntity<Void> openingMessage(@RequestParam Long userId,
+                                               @RequestParam List<Long> messageIdList) throws Exception {
+
+        log.info("[messageIdList] : {}", messageIdList);
+
+        messageService.updateMessageOpening(userId, messageIdList);
+
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/yapp/betree/controller/MessageController.java
+++ b/src/main/java/com/yapp/betree/controller/MessageController.java
@@ -1,0 +1,50 @@
+package com.yapp.betree.controller;
+
+import com.yapp.betree.dto.request.MessageRequestDto;
+import com.yapp.betree.service.MessageService;
+import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Api
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class MessageController {
+
+    private final MessageService messageService;
+
+
+    /**
+     * 칭찬 메세지 생성 (물 주기)
+     * @param data       HTTP header
+     * @param requestDto messageRequestDto
+     */
+    @PostMapping("/api/messages")
+    public ResponseEntity<Object> createMessage(@RequestHeader Map<String, String> data,
+                                                @RequestBody MessageRequestDto requestDto) {
+
+        log.info("[HeaderMap] : {}", data);
+
+        String token = data.getOrDefault("Authorization", String.valueOf(0));
+
+        long userId;
+        if (!Objects.equals(token, "0")) {
+            //TO-DO
+            //디코딩 하는 부분
+            //나중에 util로 빼더라도.. 일단 이런 식이 괜찮은 지 적어봤습니다..
+            userId = 30L;
+        } else {
+            userId = 1L;
+        }
+
+        messageService.createMessage(userId, requestDto);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/yapp/betree/controller/NoticeTreeController.java
+++ b/src/main/java/com/yapp/betree/controller/NoticeTreeController.java
@@ -2,6 +2,7 @@ package com.yapp.betree.controller;
 
 import com.yapp.betree.dto.response.NoticeResponseDto;
 import com.yapp.betree.service.NoticeTreeService;
+import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Api
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -22,7 +24,7 @@ public class NoticeTreeController {
      * @param userId
      * @return NoticeResponseDto
      */
-    @GetMapping(value = "/api/notice")
+    @GetMapping("/api/notice")
     public ResponseEntity<NoticeResponseDto> getUnreadMessageList(@RequestParam Long userId) {
 
         log.info("[userId] : {}", userId);

--- a/src/main/java/com/yapp/betree/domain/Message.java
+++ b/src/main/java/com/yapp/betree/domain/Message.java
@@ -22,7 +22,7 @@ public class Message extends BaseTimeEntity {
     private String content;
 
     @Column(nullable = false)
-    private Long sender;
+    private Long senderId;
 
     private boolean anonymous;
     private boolean alreadyRead;
@@ -38,15 +38,29 @@ public class Message extends BaseTimeEntity {
     private Folder folder;
 
     @Builder
-    public Message(Long id, String content, Long sender, boolean anonymous, boolean alreadyRead, boolean favorite, boolean opening, User user, Folder folder) {
+    public Message(Long id, String content, Long senderId, boolean anonymous, boolean alreadyRead, boolean favorite, boolean opening, User user, Folder folder) {
         this.id = id;
         this.content = content;
-        this.sender = sender;
+        this.senderId = senderId;
         this.anonymous = anonymous;
         this.alreadyRead = alreadyRead;
         this.favorite = favorite;
         this.opening = opening;
         this.user = user;
         this.folder = folder;
+    }
+
+    /**
+     * 읽음 여부 상태 변경 메서드
+     */
+    public void updateAlreadyRead() {
+        this.alreadyRead = !this.alreadyRead;
+    }
+
+    /**
+     * 익명 여부 상태 변경 메서드
+     */
+    public void updateAnonymous() {
+        this.anonymous = !this.anonymous;
     }
 }

--- a/src/main/java/com/yapp/betree/domain/Message.java
+++ b/src/main/java/com/yapp/betree/domain/Message.java
@@ -63,4 +63,12 @@ public class Message extends BaseTimeEntity {
     public void updateAnonymous() {
         this.anonymous = !this.anonymous;
     }
+
+    /**
+     * 공개 여부 상태 변경 메서드
+     */
+    public void updateOpening() {
+        this.opening = !this.opening;
+    }
+
 }

--- a/src/main/java/com/yapp/betree/dto/request/MessageRequestDto.java
+++ b/src/main/java/com/yapp/betree/dto/request/MessageRequestDto.java
@@ -11,14 +11,14 @@ public class MessageRequestDto {
 
     private Long receiverId;
     private String content;
-    private String folderName;
+    private Long folderId;
     private boolean anonymous;
 
     @Builder
-    public MessageRequestDto(Long receiverId, String content, String folderName, boolean anonymous) {
+    public MessageRequestDto(Long receiverId, String content, Long folderId, boolean anonymous) {
         this.receiverId = receiverId;
         this.content = content;
-        this.folderName = folderName;
+        this.folderId = folderId;
         this.anonymous = anonymous;
     }
 }

--- a/src/main/java/com/yapp/betree/dto/request/MessageRequestDto.java
+++ b/src/main/java/com/yapp/betree/dto/request/MessageRequestDto.java
@@ -1,0 +1,24 @@
+package com.yapp.betree.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessageRequestDto {
+
+    private Long receiverId;
+    private String content;
+    private String folderName;
+    private boolean anonymous;
+
+    @Builder
+    public MessageRequestDto(Long receiverId, String content, String folderName, boolean anonymous) {
+        this.receiverId = receiverId;
+        this.content = content;
+        this.folderName = folderName;
+        this.anonymous = anonymous;
+    }
+}

--- a/src/main/java/com/yapp/betree/dto/response/MessageBoxResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessageBoxResponseDto.java
@@ -1,0 +1,35 @@
+package com.yapp.betree.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.yapp.betree.domain.Message;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MessageBoxResponseDto {
+
+    private Long id;
+    private String content;
+    private boolean anonymous;
+    private boolean alreadyRead;
+    private boolean favorite;
+    private boolean opening;
+    private String senderNickName;
+    private String senderProfileImage;
+
+    @Builder
+    public MessageBoxResponseDto(Message message, String senderNickName, String senderProfileImage) {
+        this.id = message.getId();
+        this.content = message.getContent();
+        this.anonymous = message.isAnonymous();
+        this.alreadyRead = message.isAlreadyRead();
+        this.favorite = message.isFavorite();
+        this.opening = message.isOpening();
+        this.senderNickName = senderNickName;
+        this.senderProfileImage = senderProfileImage;
+    }
+}

--- a/src/main/java/com/yapp/betree/dto/response/MessagePageResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessagePageResponseDto.java
@@ -1,0 +1,20 @@
+package com.yapp.betree.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessagePageResponseDto {
+
+    private List<MessageBoxResponseDto> responseDto;
+    private boolean hasNext;
+
+    public MessagePageResponseDto(List<MessageBoxResponseDto> responseDto, boolean hasNext) {
+        this.responseDto = responseDto;
+        this.hasNext = hasNext;
+    }
+}

--- a/src/main/java/com/yapp/betree/repository/FolderRepository.java
+++ b/src/main/java/com/yapp/betree/repository/FolderRepository.java
@@ -6,5 +6,4 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FolderRepository extends JpaRepository<Folder, Long> {
-    Folder findByUserIdAndName(Long userId, String name);
 }

--- a/src/main/java/com/yapp/betree/repository/FolderRepository.java
+++ b/src/main/java/com/yapp/betree/repository/FolderRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FolderRepository extends JpaRepository<Folder, Long> {
+    Folder findByUserIdAndName(Long userId, String name);
 }

--- a/src/main/java/com/yapp/betree/repository/MessageRepository.java
+++ b/src/main/java/com/yapp/betree/repository/MessageRepository.java
@@ -1,9 +1,16 @@
 package com.yapp.betree.repository;
 
 import com.yapp.betree.domain.Message;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
+    List<Message> findByUserIdAndOpening(Long userId, boolean opening);
+
+    Slice<Message> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -35,7 +35,7 @@ public class MessageService {
                 NoSuchElementException::new
         );
 
-        Folder folder = folderRepository.findByUserIdAndName(requestDto.getReceiverId(), requestDto.getFolderName());
+        Folder folder = folderRepository.getById(requestDto.getFolderId());
 
         Message message = Message.builder()
                 .senderId(senderId)

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -1,0 +1,60 @@
+package com.yapp.betree.service;
+
+import com.yapp.betree.domain.Folder;
+import com.yapp.betree.domain.Message;
+import com.yapp.betree.domain.User;
+import com.yapp.betree.dto.request.MessageRequestDto;
+import com.yapp.betree.repository.FolderRepository;
+import com.yapp.betree.repository.MessageRepository;
+import com.yapp.betree.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MessageService {
+
+    private final UserRepository userRepository;
+    private final FolderRepository folderRepository;
+    private final MessageRepository messageRepository;
+
+    /**
+     * 칭찬 메세지 생성 (물 주기)
+     * @param senderId   발신유저아이디
+     * @param requestDto messageRequestDto
+     */
+    public void createMessage(Long senderId, MessageRequestDto requestDto) {
+
+        //수신자 유저 객체 조회
+        User user = userRepository.findById(requestDto.getReceiverId()).orElseThrow(
+                NoSuchElementException::new
+        );
+
+        Folder folder = folderRepository.findByUserIdAndName(requestDto.getReceiverId(), requestDto.getFolderName());
+
+        Message message = Message.builder()
+                .senderId(senderId)
+                .user(user)
+                .anonymous(requestDto.isAnonymous())
+                .content(requestDto.getContent())
+                .folder(folder)
+                .build();
+
+        //로그인 안 한 상태에서 메세지 전송시 익명 여부 true 설정
+        if (senderId == 1L) {
+            message.updateAnonymous();
+        }
+
+        // 본인에게 보낸 메세지일 때 읽음 여부 true 설정
+        if (Objects.equals(senderId, requestDto.getReceiverId())) {
+            message.updateAlreadyRead();
+        }
+
+        messageRepository.save(message);
+    }
+}

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -30,6 +30,8 @@ public class MessageService {
     private final FolderRepository folderRepository;
     private final MessageRepository messageRepository;
 
+    private static final int PAGE_SIZE = 7;
+
     /**
      * 칭찬 메세지 생성 (물 주기)
      *
@@ -74,7 +76,7 @@ public class MessageService {
      */
     public MessagePageResponseDto getMessageList(Long userId, int page) {
 
-        PageRequest pageRequest = PageRequest.of(page, 7, Sort.by(Sort.Direction.DESC, "createdDate"));
+        PageRequest pageRequest = PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdDate"));
 
         boolean hasNext = messageRepository.findByUserId(userId, pageRequest).hasNext();
 

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -4,15 +4,22 @@ import com.yapp.betree.domain.Folder;
 import com.yapp.betree.domain.Message;
 import com.yapp.betree.domain.User;
 import com.yapp.betree.dto.request.MessageRequestDto;
+import com.yapp.betree.dto.response.MessageBoxResponseDto;
+import com.yapp.betree.dto.response.MessagePageResponseDto;
 import com.yapp.betree.repository.FolderRepository;
 import com.yapp.betree.repository.MessageRepository;
 import com.yapp.betree.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +32,7 @@ public class MessageService {
 
     /**
      * 칭찬 메세지 생성 (물 주기)
+     *
      * @param senderId   발신유저아이디
      * @param requestDto messageRequestDto
      */
@@ -57,4 +65,47 @@ public class MessageService {
 
         messageRepository.save(message);
     }
+
+    /**
+     * 메세지함 목록 조회
+     *
+     * @param userId
+     */
+    public MessagePageResponseDto getMessageList(Long userId, int page) {
+
+        PageRequest pageRequest = PageRequest.of(page, 7, Sort.by(Sort.Direction.DESC, "createdDate"));
+
+        boolean hasNext = messageRepository.findByUserId(userId, pageRequest).hasNext();
+
+        List<MessageBoxResponseDto> responseDtos = messageRepository.findByUserId(userId, pageRequest)
+                .stream()
+                .map(message -> new MessageBoxResponseDto(message,
+                        message.getUser().getNickName(),
+                        message.getUser().getUserImage()))
+                .collect(Collectors.toList());
+        return new MessagePageResponseDto(responseDtos, hasNext);
+    }
+
+    /**
+     * 선택한 메세지 공개로 설정 (열매 맺기)
+     *
+     * @param messageIdList 선택한 메세지 ID list
+     */
+    public void updateMessageOpening(Long userId, List<Long> messageIdList) throws Exception {
+        //선택한 개수 8개 초과면 오류
+        if (messageIdList.size() > 8) {
+            throw new Exception();
+        }
+        //이미 선택된 메세지 가져와서 false로 변경
+        List<Message> messages = messageRepository.findByUserIdAndOpening(userId, true);
+        for (Message m : messages) {
+            m.updateOpening();
+        }
+        // 지금 선택된 메세지만 true로 변경
+        for (Long id : messageIdList) {
+            Optional<Message> message = messageRepository.findById(id);
+            message.ifPresent(Message::updateOpening);
+        }
+    }
+
 }

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class MessageService {
 
     private final UserRepository userRepository;
@@ -36,6 +36,7 @@ public class MessageService {
      * @param senderId   발신유저아이디
      * @param requestDto messageRequestDto
      */
+    @Transactional
     public void createMessage(Long senderId, MessageRequestDto requestDto) {
 
         //수신자 유저 객체 조회
@@ -91,6 +92,7 @@ public class MessageService {
      *
      * @param messageIdList 선택한 메세지 ID list
      */
+    @Transactional
     public void updateMessageOpening(Long userId, List<Long> messageIdList) throws Exception {
         //선택한 개수 8개 초과면 오류
         if (messageIdList.size() > 8) {

--- a/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
@@ -1,0 +1,100 @@
+package com.yapp.betree.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yapp.betree.domain.Folder;
+import com.yapp.betree.domain.FruitType;
+import com.yapp.betree.domain.User;
+import com.yapp.betree.repository.FolderRepository;
+import com.yapp.betree.repository.MessageRepository;
+import com.yapp.betree.repository.UserRepository;
+import com.yapp.betree.service.MessageService;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("MessageController Test")
+class MessageControllerTest {
+
+    @Autowired
+    MessageController messageController;
+    @Autowired
+    MessageService messageService;
+    @Autowired
+    MessageRepository messageRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    FolderRepository folderRepository;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    private User user;
+    private Folder folder;
+
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(messageController)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true)) // utf-8 필터 추가
+                .build();
+    }
+
+    @BeforeEach
+    void init() {
+
+        user = User.builder()
+                .nickName("user")
+                .email("user@user.com")
+                .url("testUrl")
+                .lastAccessTime(LocalDateTime.now())
+                .userImage("123")
+                .build();
+
+        userRepository.save(user);
+
+        folder = Folder.builder()
+                .fruit(FruitType.DEFAULT)
+                .name("default")
+                .user(user)
+                .level(0L)
+                .build();
+
+        folderRepository.save(folder);
+    }
+
+    @DisplayName("메세지 생성")
+    @Test
+    void createMessage() throws Exception {
+
+        Map<String, Object> input = new HashMap<>();
+
+        input.put("receiverId", user.getId());
+        input.put("content", "컨트롤러 테스트");
+        input.put("folderName", "default");
+        input.put("anonymous", false);
+
+        mockMvc.perform(post("/api/messages")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(input)))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
@@ -13,12 +13,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -68,6 +69,34 @@ class MessageControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(input)))
                 .andDo(print())
-                .andExpect(status().isCreated());
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("메세지함 목록 조회")
+    @Test
+    void getMessageList() throws Exception {
+
+        mockMvc.perform(get("/api/messages")
+                        .param("userId", String.valueOf(1L))
+                        .param("page", String.valueOf(1)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+    }
+
+    @DisplayName("열매 맺기")
+    @Test
+    void updateMessageOpening() throws Exception {
+
+        List<String> idList = Arrays.asList(String.valueOf(9L),String.valueOf(10L));
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.addAll("messageIdList", idList);
+
+
+        mockMvc.perform(put("/api/messages/opening")
+                        .param("userId", String.valueOf(1L))
+                        .params(params))
+                .andDo(print())
+                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
@@ -69,7 +69,7 @@ class MessageControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(input)))
                 .andDo(print())
-                .andExpect(status().isNoContent());
+                .andExpect(status().isCreated());
     }
 
     @DisplayName("메세지함 목록 조회")
@@ -97,6 +97,6 @@ class MessageControllerTest {
                         .param("userId", String.valueOf(1L))
                         .params(params))
                 .andDo(print())
-                .andExpect(status().isNoContent());
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
@@ -1,8 +1,6 @@
 package com.yapp.betree.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yapp.betree.domain.Folder;
-import com.yapp.betree.domain.FruitType;
 import com.yapp.betree.domain.User;
 import com.yapp.betree.repository.FolderRepository;
 import com.yapp.betree.repository.MessageRepository;
@@ -17,7 +15,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,9 +43,6 @@ class MessageControllerTest {
     @Autowired
     protected MockMvc mockMvc;
 
-    private User user;
-    private Folder folder;
-
 
     @BeforeEach
     void setUp() {
@@ -57,44 +51,23 @@ class MessageControllerTest {
                 .build();
     }
 
-    @BeforeEach
-    void init() {
-
-        user = User.builder()
-                .nickName("user")
-                .email("user@user.com")
-                .url("testUrl")
-                .lastAccessTime(LocalDateTime.now())
-                .userImage("123")
-                .build();
-
-        userRepository.save(user);
-
-        folder = Folder.builder()
-                .fruit(FruitType.DEFAULT)
-                .name("default")
-                .user(user)
-                .level(0L)
-                .build();
-
-        folderRepository.save(folder);
-    }
-
     @DisplayName("메세지 생성")
     @Test
     void createMessage() throws Exception {
+
+        User user = userRepository.findById(1L).orElseThrow(Exception::new);
 
         Map<String, Object> input = new HashMap<>();
 
         input.put("receiverId", user.getId());
         input.put("content", "컨트롤러 테스트");
-        input.put("folderName", "default");
+        input.put("folderId", 10L);
         input.put("anonymous", false);
 
         mockMvc.perform(post("/api/messages")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(input)))
                 .andDo(print())
-                .andExpect(status().isNoContent());
+                .andExpect(status().isCreated());
     }
 }


### PR DESCRIPTION
## 이슈
- #12 

## 작업 내용
- 칭찬 메세지 생성 API
- Controller Test Case 작성
++
- 열매 맺기
- 메세지 목록 조회 (메세지함에서 보는 부분) - 페이징 처리 (무한 스크롤로 total count대신 hasNext 값 리턴)
(hasNext - 다음 페이지 존재 여부)

## 기타 사항
- jwt 토큰 디코딩 하는 부분 추가 필요
- message에서 sender -> senderId로 변경
++
- 열매 맺기가 메세지함쪽이라 messageController 있는 브랜치에 추가로 했습니다.
- 열매 맺으려면 메세지 리스트에서 선택해서 해야겠네 그럼 목록 가져오기도 해야겠다.. ! 하고 메세지함 목록 조회 API도 추가를 했는데.. 조금 성급하게 한 것 같습니다 상의없이 해서 죄송해요 ㅠㅠ
나무와 메세지함에서 보여지는 메세지 상세 옵션이 달라서(즐겨찾기 등) dto를 합칠까 하다가 나눴는데 dto명이 조금 복잡하게 되서 수정이 필요합니다.
- [ ] messageboxResponseDto에 받은 시간 추가 필요

## 체크리스트