### PR TITLE
feat: 카카오 로그인/회원가입 #14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     //Swagger
     implementation "io.springfox:springfox-boot-starter:3.0.0"
+    // WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux' // WebClient 테스트
+    testImplementation group: 'com.squareup.okhttp', name: 'mockwebserver', version: '1.2.1'
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.2.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 
     // 테스트용 H2
     runtimeOnly 'com.h2database:h2'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux' // WebClient 테스트
     testImplementation group: 'com.squareup.okhttp', name: 'mockwebserver', version: '1.2.1'
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.2.0'
+
+    // 테스트용 H2
+    runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/yapp/betree/annotation/LoginUser.java
+++ b/src/main/java/com/yapp/betree/annotation/LoginUser.java
@@ -1,0 +1,11 @@
+package com.yapp.betree.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface LoginUser {
+}

--- a/src/main/java/com/yapp/betree/config/WebConfig.java
+++ b/src/main/java/com/yapp/betree/config/WebConfig.java
@@ -1,16 +1,31 @@
 package com.yapp.betree.config;
 
+import com.yapp.betree.interceptor.TokenInterceptor;
+import com.yapp.betree.service.oauth.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
                 .allowedOrigins("*")
                 .allowedMethods("*")
                 .maxAge(3000);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new TokenInterceptor(jwtTokenProvider))
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/signin", "api/refresh-token");
     }
 }

--- a/src/main/java/com/yapp/betree/config/WebConfig.java
+++ b/src/main/java/com/yapp/betree/config/WebConfig.java
@@ -1,12 +1,16 @@
 package com.yapp.betree.config;
 
 import com.yapp.betree.interceptor.TokenInterceptor;
+import com.yapp.betree.interceptor.UserHandlerMethodArgumentResolver;
 import com.yapp.betree.service.oauth.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -26,6 +30,11 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new TokenInterceptor(jwtTokenProvider))
                 .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/signin", "api/refresh-token");
+                .excludePathPatterns("/api/signin", "/api/refresh-token");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new UserHandlerMethodArgumentResolver());
     }
 }

--- a/src/main/java/com/yapp/betree/config/WebConfig.java
+++ b/src/main/java/com/yapp/betree/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.yapp.betree.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
+                .maxAge(3000);
+    }
+}

--- a/src/main/java/com/yapp/betree/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/yapp/betree/config/swagger/SwaggerConfig.java
@@ -6,9 +6,16 @@ import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableSwagger2
@@ -22,6 +29,8 @@ public class SwaggerConfig {
     @Bean
     public Docket swggerAPI() {
         return new Docket(DocumentationType.SWAGGER_2)
+                .securitySchemes(Arrays.asList(apiKey()))
+                .securityContexts(Arrays.asList(securityContext()))
                 .forCodeGeneration(true)
                 .select()
                 .apis(RequestHandlerSelectors.any())
@@ -30,6 +39,23 @@ public class SwaggerConfig {
                 .apiInfo(apiInfo())
                 .enable(true)
                 .useDefaultResponseMessages(false);
+    }
+
+    private ApiKey apiKey() {
+        return new ApiKey("JWT", "Authorization", "header");
+    }
+
+    private SecurityContext securityContext() {
+        return SecurityContext.builder()
+                .securityReferences(defaultAuth())
+                .build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return Arrays.asList(new SecurityReference("JWT", authorizationScopes));
     }
 
     /**

--- a/src/main/java/com/yapp/betree/controller/ForestController.java
+++ b/src/main/java/com/yapp/betree/controller/ForestController.java
@@ -1,5 +1,7 @@
 package com.yapp.betree.controller;
 
+import com.yapp.betree.annotation.LoginUser;
+import com.yapp.betree.dto.LoginUserDto;
 import com.yapp.betree.dto.response.ForestResponseDto;
 import com.yapp.betree.dto.response.TreeFullResponseDto;
 import com.yapp.betree.service.FolderService;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 @Api
 @RestController
@@ -22,19 +25,20 @@ public class ForestController {
 
     /**
      * 유저 나무숲 조회
-     * @param userId
+     *
+     * @param loginUser
      * @return ForestResponseDto
      */
     @GetMapping("/api/forest")
-    public ResponseEntity<ForestResponseDto> userForest(
-            @RequestParam Long userId) {
+    public ResponseEntity<ForestResponseDto> userForest(@ApiIgnore @LoginUser LoginUserDto loginUser) {
 
-        log.info("나무숲 조회 userId: {}", userId);
-        return ResponseEntity.ok(folderService.userForest(userId));
+        log.info("나무숲 조회 userId: {}", loginUser.getId());
+        return ResponseEntity.ok(folderService.userForest(loginUser.getId()));
     }
 
     /**
      * 유저 상세 나무 조회
+     *
      * @param userId
      * @param treeId
      * @return TreeFullResponseDto

--- a/src/main/java/com/yapp/betree/controller/OAuthController.java
+++ b/src/main/java/com/yapp/betree/controller/OAuthController.java
@@ -1,8 +1,13 @@
 package com.yapp.betree.controller;
 
 import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.exception.ErrorCode;
 import com.yapp.betree.service.oauth.KakaoApiService;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -24,12 +29,19 @@ public class OAuthController {
      * @param accessToken
      * @return
      */
+    @ApiOperation(value = "OAuth 인증", notes = "카카오에서 받아온 토큰으로 로그인(회원가입)")
+    @ApiResponses({
+            @ApiResponse(code = 400, message = "[C001]Invalid input value(Required request header is not present)\n" +
+                    "[O001]OAuth로 받아온 유저정보가 올바르지 않습니다.\n" +
+                    "[O002]OAuth로 받아온 액세스 토큰이 만료되었습니다.\n"),
+            @ApiResponse(code = 500, message = "[C002]Internal server error(kakao api요청 실패)"),
+    })
     @GetMapping("/api/signin")
     public ResponseEntity<OAuthUserInfoDto> oauthTest(@RequestHeader("X-Kakao-Access-Token") String accessToken) {
         log.info("카카오 로그인 요청 accessToken: {}", accessToken);
 
         if (!kakaoApiService.supports(accessToken)) {
-            throw new IllegalArgumentException("토큰이 만료되었습니다. accessToken: " + accessToken);
+            throw new BetreeException(ErrorCode.OAUTH_ACCESS_TOKEN_EXPIRED, "accessToken = " + accessToken);
         }
 
         OAuthUserInfoDto oAuthUserInfoDto = kakaoApiService.getUserInfo(accessToken);

--- a/src/main/java/com/yapp/betree/controller/OAuthController.java
+++ b/src/main/java/com/yapp/betree/controller/OAuthController.java
@@ -1,5 +1,6 @@
 package com.yapp.betree.controller;
 
+import com.yapp.betree.dto.oauth.JwtTokenDto;
 import com.yapp.betree.service.LoginService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -34,11 +35,11 @@ public class OAuthController {
                     "[O002]OAuth로 받아온 액세스 토큰이 만료되었습니다.\n"),
     })
     @GetMapping("/api/signin")
-    public ResponseEntity<String> signIn(@RequestHeader("X-Kakao-Access-Token") String accessToken) {
+    public ResponseEntity<JwtTokenDto> signIn(@RequestHeader("X-Kakao-Access-Token") String accessToken) {
         log.info("회원 로그인 요청 accessToken: {}", accessToken);
 
-        // TODO jwt토큰 발급
-        String betreeToken = loginService.createToken(accessToken);
-        return ResponseEntity.ok(betreeToken);
+        JwtTokenDto token = loginService.createToken(accessToken);
+        log.info("JWT 토큰 발급 : {}", token);
+        return ResponseEntity.ok(token);
     }
 }

--- a/src/main/java/com/yapp/betree/controller/OAuthController.java
+++ b/src/main/java/com/yapp/betree/controller/OAuthController.java
@@ -31,10 +31,10 @@ public class OAuthController {
      */
     @ApiOperation(value = "OAuth 인증", notes = "카카오에서 받아온 토큰으로 로그인(회원가입)")
     @ApiResponses({
-            @ApiResponse(code = 400, message = "[C001]Invalid input value(Required request header is not present)\n" +
-                    "[O001]OAuth로 받아온 유저정보가 올바르지 않습니다.\n" +
+            @ApiResponse(code = 400, message = "[C001]Invalid input value(Required request header is not present)"),
+            @ApiResponse(code = 401, message = "[O000]OAuth 서버와의 연동에 실패했습니다.(kakao api 실패, 토큰 만료 등)\n" +
+                    "[O001]OAuth로 받아온 유저정보가 올바르지 않습니다. - 이메일 누락 등 \n" +
                     "[O002]OAuth로 받아온 액세스 토큰이 만료되었습니다.\n"),
-            @ApiResponse(code = 500, message = "[C002]Internal server error(kakao api요청 실패)"),
     })
     @GetMapping("/api/signin")
     public ResponseEntity<OAuthUserInfoDto> oauthTest(@RequestHeader("X-Kakao-Access-Token") String accessToken) {

--- a/src/main/java/com/yapp/betree/controller/OAuthController.java
+++ b/src/main/java/com/yapp/betree/controller/OAuthController.java
@@ -1,9 +1,6 @@
 package com.yapp.betree.controller;
 
-import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
-import com.yapp.betree.exception.BetreeException;
-import com.yapp.betree.exception.ErrorCode;
-import com.yapp.betree.service.oauth.KakaoApiService;
+import com.yapp.betree.service.LoginService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -21,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class OAuthController {
 
-    private final KakaoApiService kakaoApiService;
+    private final LoginService loginService;
 
     /**
      * 카카오 OAuth이용한 로그인 [토큰검증 - 토큰에서 사용자 정보 획득(+회원가입) - JWT토큰 발급]
@@ -37,17 +34,11 @@ public class OAuthController {
                     "[O002]OAuth로 받아온 액세스 토큰이 만료되었습니다.\n"),
     })
     @GetMapping("/api/signin")
-    public ResponseEntity<OAuthUserInfoDto> oauthTest(@RequestHeader("X-Kakao-Access-Token") String accessToken) {
-        log.info("카카오 로그인 요청 accessToken: {}", accessToken);
-
-        if (!kakaoApiService.supports(accessToken)) {
-            throw new BetreeException(ErrorCode.OAUTH_ACCESS_TOKEN_EXPIRED, "accessToken = " + accessToken);
-        }
-
-        OAuthUserInfoDto oAuthUserInfoDto = kakaoApiService.getUserInfo(accessToken);
-        log.info("카카오 유저 정보 : {}", oAuthUserInfoDto);
+    public ResponseEntity<String> signIn(@RequestHeader("X-Kakao-Access-Token") String accessToken) {
+        log.info("회원 로그인 요청 accessToken: {}", accessToken);
 
         // TODO jwt토큰 발급
-        return ResponseEntity.ok(oAuthUserInfoDto);
+        String betreeToken = loginService.createToken(accessToken);
+        return ResponseEntity.ok(betreeToken);
     }
 }

--- a/src/main/java/com/yapp/betree/controller/OAuthController.java
+++ b/src/main/java/com/yapp/betree/controller/OAuthController.java
@@ -1,6 +1,8 @@
 package com.yapp.betree.controller;
 
 import com.yapp.betree.dto.oauth.JwtTokenDto;
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.exception.ErrorCode;
 import com.yapp.betree.service.LoginService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -16,13 +18,17 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 
 @Api
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 public class OAuthController {
+
+    public static final int BEARER_INDEX = 7;
 
     private final LoginService loginService;
 
@@ -32,7 +38,7 @@ public class OAuthController {
      * @param accessToken
      * @return
      */
-    @ApiOperation(value = "OAuth 인증", notes = "카카오에서 받아온 토큰으로 로그인(회원가입\n" +
+    @ApiOperation(value = "OAuth 인증", notes = "카카오에서 받아온 토큰으로 로그인(회원가입)\n" +
             "요청 완료시 쿠키(HttpOnly)로 리프레시 토큰, 헤더(Authorization)로 Bearer accessToken이 발급됩니다.")
     @ApiResponses({
             @ApiResponse(code = 400, message = "[C001]Invalid input value(Required request header is not present)"),
@@ -46,6 +52,39 @@ public class OAuthController {
         log.info("회원 로그인 요청 accessToken: {}", accessToken);
 
         JwtTokenDto token = loginService.createToken(accessToken);
+        log.info("JWT 토큰 발급 : {}", token);
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", token.getRefreshToken())
+                .maxAge(24 * 60 * 60 * 7)
+                .path("/")
+                .secure(true)
+                .sameSite("None")
+                .httpOnly(true)
+                .build();
+        response.setHeader("Set-Cookie", cookie.toString());
+        response.setHeader("Authorization", "Bearer " + token.getAccessToken());
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @ApiOperation(value = "토큰 재발급", notes = "RefreshToken으로 AccessToken 재발급\n" +
+            "요청 완료시 쿠키(HttpOnly)로 리프레시 토큰, 헤더(Authorization)로 Bearer accessToken이 발급됩니다.")
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "[U003]JWT 리프레시 토큰이 만료되었습니다. 재로그인이 필요합니다.\n" +
+                    "[U004]유효하지 않은 JWT 리프레시 토큰입니다. 재로그인이 필요합니다.\n"),
+            @ApiResponse(code = 404, message = "[U005]회원을 찾을 수 없습니다.")
+    })
+    @GetMapping("/api/refresh-token")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity<Void> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        // TODO token string값 검증, 필터나 인터셉터로 한번에 처리하는거 필요
+        String refreshToken = Arrays.stream(request.getCookies())
+                .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                .findAny()
+                .orElseThrow(() -> new BetreeException(ErrorCode.USER_REFRESH_ERROR, "쿠키에 토큰이 존재하지 않습니다."))
+                .getValue();
+        log.info("회원 토큰 재발급 요청 refreshToken: {}", refreshToken);
+        JwtTokenDto token = loginService.refreshToken(refreshToken);
         log.info("JWT 토큰 발급 : {}", token);
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", token.getRefreshToken())

--- a/src/main/java/com/yapp/betree/controller/OAuthController.java
+++ b/src/main/java/com/yapp/betree/controller/OAuthController.java
@@ -1,0 +1,41 @@
+package com.yapp.betree.controller;
+
+import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
+import com.yapp.betree.service.oauth.KakaoApiService;
+import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthController {
+
+    private final KakaoApiService kakaoApiService;
+
+    /**
+     * 카카오 OAuth이용한 로그인 [토큰검증 - 토큰에서 사용자 정보 획득(+회원가입) - JWT토큰 발급]
+     *
+     * @param accessToken
+     * @return
+     */
+    @GetMapping("/api/signin")
+    public ResponseEntity<OAuthUserInfoDto> oauthTest(@RequestHeader("X-Kakao-Access-Token") String accessToken) {
+        log.info("카카오 로그인 요청 accessToken: {}", accessToken);
+
+        if (!kakaoApiService.supports(accessToken)) {
+            throw new IllegalArgumentException("토큰이 만료되었습니다. accessToken: " + accessToken);
+        }
+
+        OAuthUserInfoDto oAuthUserInfoDto = kakaoApiService.getUserInfo(accessToken);
+        log.info("카카오 유저 정보 : {}", oAuthUserInfoDto);
+
+        // TODO jwt토큰 발급
+        return ResponseEntity.ok(oAuthUserInfoDto);
+    }
+}

--- a/src/main/java/com/yapp/betree/domain/Folder.java
+++ b/src/main/java/com/yapp/betree/domain/Folder.java
@@ -40,4 +40,8 @@ public class Folder extends BaseTimeEntity {
         this.level = level;
         this.user = user;
     }
+
+    public void updateUser(User user){
+        this.user = user;
+    }
 }

--- a/src/main/java/com/yapp/betree/domain/RefreshToken.java
+++ b/src/main/java/com/yapp/betree/domain/RefreshToken.java
@@ -1,0 +1,46 @@
+package com.yapp.betree.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String token;
+
+    @Builder
+    public RefreshToken(Long userId, String token) {
+        this.userId = userId;
+        this.token = token;
+    }
+
+    public void updateToken(String token) {
+        this.token = token;
+    }
+
+    public boolean isSame(String token) {
+        return Objects.equals(this.token, token);
+    }
+}

--- a/src/main/java/com/yapp/betree/domain/User.java
+++ b/src/main/java/com/yapp/betree/domain/User.java
@@ -6,10 +6,19 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -46,8 +55,11 @@ public class User extends BaseTimeEntity {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<Message> receivedMessages = new ArrayList<>();
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Folder> folders = new ArrayList<>();
+
     @Builder
-    public User(Long id, Long oauthId, String nickName, String email, String userImage, LocalDateTime lastAccessTime, String url, boolean randomMessageRemind, boolean forestOff, boolean onlyFriends, List<Message> receivedMessages) {
+    public User(Long id, Long oauthId, String nickName, String email, String userImage, LocalDateTime lastAccessTime, String url, boolean randomMessageRemind, boolean forestOff, boolean onlyFriends, List<Message> receivedMessages, List<Folder> folders) {
         this.id = id;
         this.oauthId = oauthId;
         this.nickName = nickName;
@@ -59,5 +71,17 @@ public class User extends BaseTimeEntity {
         this.forestOff = forestOff;
         this.onlyFriends = onlyFriends;
         this.receivedMessages = receivedMessages;
+        if (Objects.isNull(receivedMessages)) {
+            this.receivedMessages = new ArrayList<>();
+        }
+        this.folders = folders;
+        if (Objects.isNull(folders)) {
+            this.folders = new ArrayList<>();
+        }
+    }
+
+    public void addFolder(Folder folder) {
+        this.folders.add(folder);
+        folder.updateUser(this); // 원래 이거만 해도 추가됨
     }
 }

--- a/src/main/java/com/yapp/betree/dto/LoginUserDto.java
+++ b/src/main/java/com/yapp/betree/dto/LoginUserDto.java
@@ -30,7 +30,7 @@ public class LoginUserDto {
      */
     public static LoginUserDto of(User user) {
         return LoginUserDto.builder()
-                .id(user.getOauthId())
+                .id(user.getId())
                 .nickname(user.getNickName())
                 .email(user.getEmail())
                 .build();

--- a/src/main/java/com/yapp/betree/dto/LoginUserDto.java
+++ b/src/main/java/com/yapp/betree/dto/LoginUserDto.java
@@ -1,5 +1,7 @@
 package com.yapp.betree.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.yapp.betree.domain.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,6 +12,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LoginUserDto {
     private Long id;
     private String nickname;

--- a/src/main/java/com/yapp/betree/dto/LoginUserDto.java
+++ b/src/main/java/com/yapp/betree/dto/LoginUserDto.java
@@ -1,0 +1,38 @@
+package com.yapp.betree.dto;
+
+import com.yapp.betree.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginUserDto {
+    private Long id;
+    private String nickname;
+    private String email;
+
+    @Builder
+    public LoginUserDto(Long id, String nickname, String email) {
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+    }
+
+    /**
+     * Jwt 토큰 발급을 위한 로그인 유저 DTO
+     *
+     * @param user
+     * @return LoginUserDto
+     */
+    public static LoginUserDto of(User user) {
+        return LoginUserDto.builder()
+                .id(user.getOauthId())
+                .nickname(user.getNickName())
+                .email(user.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/yapp/betree/dto/oauth/JwtTokenDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/JwtTokenDto.java
@@ -1,0 +1,21 @@
+package com.yapp.betree.dto.oauth;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JwtTokenDto {
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public JwtTokenDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/yapp/betree/dto/oauth/KakaoAccountDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/KakaoAccountDto.java
@@ -1,0 +1,18 @@
+package com.yapp.betree.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoAccountDto {
+    @JsonProperty("profile")
+    private KakaoProfileDto profile;
+
+    @JsonProperty("email")
+    private String email;
+}

--- a/src/main/java/com/yapp/betree/dto/oauth/KakaoProfileDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/KakaoProfileDto.java
@@ -1,0 +1,15 @@
+package com.yapp.betree.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoProfileDto {
+    @JsonProperty("nickname")
+    private String nickname;
+}

--- a/src/main/java/com/yapp/betree/dto/oauth/KakaoTokenInfoDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/KakaoTokenInfoDto.java
@@ -1,0 +1,27 @@
+package com.yapp.betree.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoTokenInfoDto {
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("app_id")
+    private Integer appId;
+
+    @Builder
+    public KakaoTokenInfoDto(Long id, Integer expiresIn, Integer appId) {
+        this.id = id;
+        this.expiresIn = expiresIn;
+        this.appId = appId;
+    }
+}

--- a/src/main/java/com/yapp/betree/dto/oauth/KakaoTokenInfoDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/KakaoTokenInfoDto.java
@@ -6,10 +6,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class KakaoTokenInfoDto {
     @JsonProperty("id")
+    @NotNull
     private Long id;
 
     @JsonProperty("expires_in")

--- a/src/main/java/com/yapp/betree/dto/oauth/KakaoUserInfoDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/KakaoUserInfoDto.java
@@ -1,6 +1,8 @@
 package com.yapp.betree.dto.oauth;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.exception.ErrorCode;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +21,7 @@ public class KakaoUserInfoDto {
 
     public OAuthUserInfoDto buildUserInfo() {
         if (Objects.isNull(kakaoAccount.getEmail())) {
-            throw new IllegalStateException("카카오 유저 정보 중 email은 null일 수 없습니다."); // TODO 예외처리
+            throw new BetreeException(ErrorCode.OAUTH_INVALID_USERINFO, "Kakao email is null");
         }
         return OAuthUserInfoDto.builder()
                 .id(id)

--- a/src/main/java/com/yapp/betree/dto/oauth/KakaoUserInfoDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/KakaoUserInfoDto.java
@@ -1,0 +1,36 @@
+package com.yapp.betree.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoUserInfoDto {
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccountDto kakaoAccount;
+
+    public OAuthUserInfoDto buildUserInfo() {
+        if (Objects.isNull(kakaoAccount.getEmail())) {
+            throw new IllegalStateException("카카오 유저 정보 중 email은 null일 수 없습니다."); // TODO 예외처리
+        }
+        return OAuthUserInfoDto.builder()
+                .id(id)
+                .nickname(kakaoAccount.getProfile().getNickname())
+                .email(kakaoAccount.getEmail())
+                .build();
+    }
+
+    @Builder
+    public KakaoUserInfoDto(Long id, KakaoAccountDto kakaoAccount) {
+        this.id = id;
+        this.kakaoAccount = kakaoAccount;
+    }
+}

--- a/src/main/java/com/yapp/betree/dto/oauth/OAuthUserInfoDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/OAuthUserInfoDto.java
@@ -1,0 +1,23 @@
+package com.yapp.betree.dto.oauth;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuthUserInfoDto {
+    private Long id;
+    private String nickname;
+    private String email;
+
+    @Builder
+    public OAuthUserInfoDto(Long id, String nickname, String email) {
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/yapp/betree/dto/oauth/OAuthUserInfoDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/OAuthUserInfoDto.java
@@ -1,10 +1,14 @@
 package com.yapp.betree.dto.oauth;
 
+import com.yapp.betree.domain.User;
+import com.yapp.betree.util.BetreeUtils;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+
+import java.time.LocalDateTime;
 
 @Getter
 @ToString
@@ -19,5 +23,21 @@ public class OAuthUserInfoDto {
         this.id = id;
         this.nickname = nickname;
         this.email = email;
+    }
+
+    /**
+     * 카카오 유저 정보로부터 최초 회원가입시 User 엔티티 생성 메서드
+     *
+     * @return
+     */
+    public User generateSignUpUser() {
+        return User.builder()
+                .oauthId(id)
+                .nickName(nickname)
+                .email(email)
+                .userImage("default image uri") // TODO uri 결정
+                .lastAccessTime(LocalDateTime.now())
+                .url(BetreeUtils.makeUserAccessUrl(this))
+                .build();
     }
 }

--- a/src/main/java/com/yapp/betree/dto/oauth/OAuthUserInfoDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/OAuthUserInfoDto.java
@@ -1,5 +1,7 @@
 package com.yapp.betree.dto.oauth;
 
+import com.yapp.betree.domain.Folder;
+import com.yapp.betree.domain.FruitType;
 import com.yapp.betree.domain.User;
 import com.yapp.betree.util.BetreeUtils;
 import lombok.AccessLevel;
@@ -31,7 +33,13 @@ public class OAuthUserInfoDto {
      * @return
      */
     public User generateSignUpUser() {
-        return User.builder()
+        Folder folder = Folder.builder()
+                .fruit(FruitType.DEFAULT)
+                .level(0L)
+                .name("DEFAULT")
+                .build();
+
+        User user = User.builder()
                 .oauthId(id)
                 .nickName(nickname)
                 .email(email)
@@ -39,5 +47,7 @@ public class OAuthUserInfoDto {
                 .lastAccessTime(LocalDateTime.now())
                 .url(BetreeUtils.makeUserAccessUrl(this))
                 .build();
+        user.addFolder(folder);
+        return user;
     }
 }

--- a/src/main/java/com/yapp/betree/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/betree/exception/ErrorCode.java
@@ -16,6 +16,10 @@ public enum ErrorCode {
     OAUTH_SERVER_ERROR(401, "O000", "OAuth 서버와의 연동에 실패했습니다."),
     OAUTH_INVALID_USERINFO(401, "O001", "OAuth로 받아온 유저정보가 올바르지 않습니다."),
     OAUTH_ACCESS_TOKEN_EXPIRED(401, "O002", "OAuth로 받아온 액세스 토큰이 만료되었습니다."),
+
+    // User
+    USER_TOKEN_EXPIRED(401, "U001","JWT 토큰이 만료되었습니다. 재발급이 필요합니다."),
+    USER_TOKEN_ERROR(401,"U002","JWT 토큰 파싱에 실패했습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/yapp/betree/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/betree/exception/ErrorCode.java
@@ -13,8 +13,9 @@ public enum ErrorCode {
     METHOD_NOT_ALLOWED(405, "C003", "Method not allowed"),
 
     //OAuth
-    OAUTH_INVALID_USERINFO(400, "O001", "OAuth로 받아온 유저정보가 올바르지 않습니다."),
-    OAUTH_ACCESS_TOKEN_EXPIRED(400, "O002", "OAuth로 받아온 액세스 토큰이 만료되었습니다."),
+    OAUTH_SERVER_ERROR(401, "O000", "OAuth 서버와의 연동에 실패했습니다."),
+    OAUTH_INVALID_USERINFO(401, "O001", "OAuth로 받아온 유저정보가 올바르지 않습니다."),
+    OAUTH_ACCESS_TOKEN_EXPIRED(401, "O002", "OAuth로 받아온 액세스 토큰이 만료되었습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/yapp/betree/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/betree/exception/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     // User
     USER_TOKEN_EXPIRED(401, "U001","JWT 토큰이 만료되었습니다. 재발급이 필요합니다."),
     USER_TOKEN_ERROR(401,"U002","JWT 토큰 파싱에 실패했습니다."),
+    USER_REFRESH_TOKEN_EXPIRED(401,"U003", "JWT 리프레시 토큰이 만료되었습니다. 재로그인이 필요합니다."),
+    USER_REFRESH_ERROR(401,"U004", "유효하지 않은 JWT 리프레시 토큰입니다. 재로그인이 필요합니다."),
+    USER_NOT_FOUND(404, "U005", "회원을 찾을 수 없습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/yapp/betree/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/betree/exception/ErrorCode.java
@@ -11,6 +11,10 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(400, "C001", "Invalid input value"),
     INTERNAL_SERVER_ERROR(500, "C002", "Internal server error"),
     METHOD_NOT_ALLOWED(405, "C003", "Method not allowed"),
+
+    //OAuth
+    OAUTH_INVALID_USERINFO(400, "O001", "OAuth로 받아온 유저정보가 올바르지 않습니다."),
+    OAUTH_ACCESS_TOKEN_EXPIRED(400, "O002", "OAuth로 받아온 액세스 토큰이 만료되었습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/yapp/betree/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yapp/betree/exception/GlobalExceptionHandler.java
@@ -4,8 +4,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.reactive.function.client.WebClientException;
 
 import javax.validation.ConstraintViolationException;
 import java.util.List;
@@ -38,6 +40,28 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
         ErrorResponse er = getErrorResponse(e, errorCode);
         log.error("ConstraintViolationException[{}]", er);
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(er);
+    }
+
+    // header에 required 필드에 값이 들어오지 않은 경우
+    @ExceptionHandler(value = MissingRequestHeaderException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(Exception e) {
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        ErrorResponse er = getErrorResponse(e.getMessage(), errorCode);
+        log.error("MissingRequestHeaderExcpetion[{}]", er);
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(er);
+    }
+
+    // WebClient를 이용한 외부 API요청에 예외가 발생한 경우
+    @ExceptionHandler(value = WebClientException.class)
+    public ResponseEntity<ErrorResponse> handleWebClientException(WebClientException e) {
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        ErrorResponse er = getErrorResponse(e.getMessage(), errorCode);
+        log.error("WebClientExcpetion[{}]", er);
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(er);

--- a/src/main/java/com/yapp/betree/interceptor/TokenInterceptor.java
+++ b/src/main/java/com/yapp/betree/interceptor/TokenInterceptor.java
@@ -1,5 +1,6 @@
 package com.yapp.betree.interceptor;
 
+import com.yapp.betree.dto.LoginUserDto;
 import com.yapp.betree.exception.BetreeException;
 import com.yapp.betree.exception.ErrorCode;
 import com.yapp.betree.service.oauth.JwtTokenProvider;
@@ -15,6 +16,7 @@ import java.util.Optional;
 @Slf4j
 public class TokenInterceptor implements HandlerInterceptor {
 
+    public static final String USER_ATTR_KEY = "user";
     private final JwtTokenProvider jwtTokenProvider;
 
     public TokenInterceptor(JwtTokenProvider jwtTokenProvider) {
@@ -36,6 +38,15 @@ public class TokenInterceptor implements HandlerInterceptor {
             throw new BetreeException(ErrorCode.USER_TOKEN_ERROR, "토큰의 payload는 null일 수 없습니다.");
         }
         log.info("[토큰 검증 성공] claims: {}", claims);
+
+        if (claims.containsKey("id")) { // @LoginUser 생성 위함 -> 테스트할때는 claims가 {}라서 제외
+            request.setAttribute(USER_ATTR_KEY, LoginUserDto.builder()
+                    .id(Long.parseLong(String.valueOf(claims.get("id"))))
+                    .nickname((String) claims.get("nickname"))
+                    .email((String) claims.get("email"))
+                    .build()
+            );
+        }
         return true;
     }
 }

--- a/src/main/java/com/yapp/betree/interceptor/TokenInterceptor.java
+++ b/src/main/java/com/yapp/betree/interceptor/TokenInterceptor.java
@@ -1,0 +1,41 @@
+package com.yapp.betree.interceptor;
+
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.exception.ErrorCode;
+import com.yapp.betree.service.oauth.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Objects;
+import java.util.Optional;
+
+@Slf4j
+public class TokenInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public TokenInterceptor(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String authType = "Bearer";
+        String authHeader = Optional.ofNullable(request.getHeader("Authorization"))
+                .orElseThrow(() -> new BetreeException(ErrorCode.USER_TOKEN_ERROR, "헤더에 토큰이 존재하지 않습니다."));
+
+        if (authHeader.startsWith(authType)) {
+            authHeader = authHeader.substring(authType.length()).trim();
+        }
+
+        Claims claims = jwtTokenProvider.parseToken(authHeader);
+        if (Objects.isNull(claims)) {
+            throw new BetreeException(ErrorCode.USER_TOKEN_ERROR, "토큰의 payload는 null일 수 없습니다.");
+        }
+        log.info("[토큰 검증 성공] claims: {}", claims);
+        return true;
+    }
+}

--- a/src/main/java/com/yapp/betree/interceptor/UserHandlerMethodArgumentResolver.java
+++ b/src/main/java/com/yapp/betree/interceptor/UserHandlerMethodArgumentResolver.java
@@ -1,0 +1,39 @@
+package com.yapp.betree.interceptor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.yapp.betree.annotation.LoginUser;
+import com.yapp.betree.dto.LoginUserDto;
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.exception.ErrorCode;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static com.yapp.betree.interceptor.TokenInterceptor.USER_ATTR_KEY;
+
+public class UserHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws JsonProcessingException {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        LoginUserDto loginUserDto = (LoginUserDto) request.getAttribute(USER_ATTR_KEY);
+
+        LoginUser loginUser = parameter.getParameterAnnotation(LoginUser.class);
+
+        if (loginUser == null || loginUserDto == null) {
+            throw new BetreeException(ErrorCode.USER_NOT_FOUND, "로그인된 사용자 정보가 존재하지 않습니다. user = " + loginUserDto);
+        }
+
+        return loginUserDto;
+    }
+}

--- a/src/main/java/com/yapp/betree/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/yapp/betree/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.yapp.betree.repository;
+
+import com.yapp.betree.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
+}

--- a/src/main/java/com/yapp/betree/repository/UserRepository.java
+++ b/src/main/java/com/yapp/betree/repository/UserRepository.java
@@ -4,6 +4,9 @@ import com.yapp.betree.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByOauthId(Long oauthId);
 }

--- a/src/main/java/com/yapp/betree/service/LoginService.java
+++ b/src/main/java/com/yapp/betree/service/LoginService.java
@@ -1,0 +1,36 @@
+package com.yapp.betree.service;
+
+import com.yapp.betree.domain.User;
+import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
+import com.yapp.betree.service.oauth.KakaoApiService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class LoginService {
+
+    private final KakaoApiService kakaoApiService;
+    private final UserService userService;
+
+    public String createToken(String accessToken) {
+        // 1. 토큰 유효성 검증 및 oAuthId 획득
+        Long oauthId = kakaoApiService.getOauthId(accessToken);
+
+        // 2. 회원가입 유무 확인 및 로그인 유저 생성
+        Optional<User> loginUser = userService.findByOauthId(oauthId);
+        if (!loginUser.isPresent()) {
+            // 2-1. 카카오 API를 통해 회원가입할 유저 정보 요청
+            OAuthUserInfoDto oAuthUserInfoDto = kakaoApiService.getUserInfo(accessToken);
+            // 2-2. DB에 유저 등록(회원가입)하며 로그인 유저 생성
+            loginUser = Optional.of(userService.save(oAuthUserInfoDto.generateSignUpUser()));
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/yapp/betree/service/LoginService.java
+++ b/src/main/java/com/yapp/betree/service/LoginService.java
@@ -23,6 +23,7 @@ public class LoginService {
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Transactional
     public JwtTokenDto createToken(String accessToken) {
         // 1. 토큰 유효성 검증 및 oAuthId 획득
         Long oauthId = kakaoApiService.getOauthId(accessToken);

--- a/src/main/java/com/yapp/betree/service/LoginService.java
+++ b/src/main/java/com/yapp/betree/service/LoginService.java
@@ -1,7 +1,10 @@
 package com.yapp.betree.service;
 
 import com.yapp.betree.domain.User;
+import com.yapp.betree.dto.LoginUserDto;
+import com.yapp.betree.dto.oauth.JwtTokenDto;
 import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
+import com.yapp.betree.service.oauth.JwtTokenProvider;
 import com.yapp.betree.service.oauth.KakaoApiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +21,9 @@ public class LoginService {
 
     private final KakaoApiService kakaoApiService;
     private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public String createToken(String accessToken) {
+    public JwtTokenDto createToken(String accessToken) {
         // 1. 토큰 유효성 검증 및 oAuthId 획득
         Long oauthId = kakaoApiService.getOauthId(accessToken);
 
@@ -31,6 +35,7 @@ public class LoginService {
             // 2-2. DB에 유저 등록(회원가입)하며 로그인 유저 생성
             loginUser = Optional.of(userService.save(oAuthUserInfoDto.generateSignUpUser()));
         }
-        return null;
+
+        return jwtTokenProvider.createToken(LoginUserDto.of(loginUser.get()));
     }
 }

--- a/src/main/java/com/yapp/betree/service/UserService.java
+++ b/src/main/java/com/yapp/betree/service/UserService.java
@@ -1,6 +1,10 @@
 package com.yapp.betree.service;
 
+import com.yapp.betree.domain.RefreshToken;
 import com.yapp.betree.domain.User;
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.exception.ErrorCode;
+import com.yapp.betree.repository.RefreshTokenRepository;
 import com.yapp.betree.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,14 +20,45 @@ import java.util.Optional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     Optional<User> findByOauthId(Long oauthId) {
         log.info("oauthId로 유저 조회 : oauthId = {}", oauthId);
         return userRepository.findByOauthId(oauthId);
     }
 
+    Optional<User> findById(Long userId) {
+        log.info("userId로 유저 조회 : userId = {}", userId);
+        return userRepository.findById(userId);
+    }
+
+    @Transactional
     User save(User user) {
         log.info("User 등록 : {}", user);
         return userRepository.save(user);
+    }
+
+    @Transactional
+    void saveRefreshToken(String token, Long userId) {
+        Optional<RefreshToken> byUserId = refreshTokenRepository.findByUserId(userId);
+        if(!byUserId.isPresent()) {
+            log.info("refreshToken 생성 : token = {}, userId = {}", token, userId);
+            RefreshToken refreshToken = RefreshToken.builder()
+                    .token(token)
+                    .userId(userId)
+                    .build();
+            refreshTokenRepository.save(refreshToken);
+            return;
+        }
+        log.info("refreshToken 갱신 : token = {}, userId = {}", token, userId);
+        RefreshToken refreshToken = byUserId.get();
+        refreshToken.updateToken(token);
+    }
+
+    boolean isValidRefreshToken(String token, Long userId) {
+        log.info("id로 refreshToken 조회 : userId = {}", userId);
+        RefreshToken refreshToken = refreshTokenRepository.findByUserId(userId)
+                .orElseThrow(() -> new BetreeException(ErrorCode.USER_REFRESH_ERROR, "userId = " + userId));
+        return refreshToken.isSame(token);
     }
 }

--- a/src/main/java/com/yapp/betree/service/UserService.java
+++ b/src/main/java/com/yapp/betree/service/UserService.java
@@ -1,0 +1,29 @@
+package com.yapp.betree.service;
+
+import com.yapp.betree.domain.User;
+import com.yapp.betree.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    Optional<User> findByOauthId(Long oauthId) {
+        log.info("oauthId로 유저 조회 : oauthId = {}", oauthId);
+        return userRepository.findByOauthId(oauthId);
+    }
+
+    User save(User user) {
+        log.info("User 등록 : {}", user);
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/yapp/betree/service/oauth/JwtTokenProvider.java
+++ b/src/main/java/com/yapp/betree/service/oauth/JwtTokenProvider.java
@@ -1,0 +1,83 @@
+package com.yapp.betree.service.oauth;
+
+import com.yapp.betree.dto.LoginUserDto;
+import com.yapp.betree.dto.oauth.JwtTokenDto;
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@Slf4j
+public class JwtTokenProvider {
+    public static final String ISSUER = "BeTree";
+    public static final int DAYS = 7;
+
+    private final String secretKey;
+    private final Long tokenValidMilliseconds;
+    private final Long refreshTokenValidMilliseconds;
+
+    @Autowired
+    public JwtTokenProvider(@Value("${secrets.jwt.token.secret-key}") String secretKey,
+                            @Value("${secrets.jwt.token.expiration-time}") Long tokenValidMilliseconds,
+                            @Value("${secrets.jwt.token.refresh-expiration-time}") Long refreshTokenValidMilliseconds) {
+        this.secretKey = secretKey;
+        this.tokenValidMilliseconds = tokenValidMilliseconds; // 1시간
+        this.refreshTokenValidMilliseconds = refreshTokenValidMilliseconds * DAYS; // 하루 * days
+    }
+
+    public JwtTokenDto createToken(LoginUserDto user) {
+        return JwtTokenDto.builder()
+                .accessToken(createAccessToken(user))
+                .refreshToken(createRefreshToken())
+                .build();
+    }
+
+    String createAccessToken(LoginUserDto user) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuer(ISSUER)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenValidMilliseconds))
+                .claim("id", user.getId())
+                .claim("nickname", user.getNickname())
+                .claim("email", user.getEmail())
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    String createRefreshToken() {
+        Date now = new Date();
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuer(ISSUER)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + refreshTokenValidMilliseconds))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public Claims parseToken(String token) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new BetreeException(ErrorCode.USER_TOKEN_EXPIRED, "token = " + token);
+        } catch (JwtException e) {
+            throw new BetreeException(ErrorCode.USER_TOKEN_ERROR, "token = " + token);
+        }
+    }
+}

--- a/src/main/java/com/yapp/betree/service/oauth/KakaoApiService.java
+++ b/src/main/java/com/yapp/betree/service/oauth/KakaoApiService.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientException;
 
 @Service
 @Slf4j
@@ -41,44 +40,34 @@ public class KakaoApiService {
      * @return boolean
      */
     public boolean supports(String accessToken) {
-        try {
-            KakaoTokenInfoDto kakaoTokenInfoDto = webClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path(KAKAO_TOKEN_INFO_URL)
-                            .build())
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                    .retrieve()
-                    .bodyToMono(KakaoTokenInfoDto.class)
-                    .block();
+        KakaoTokenInfoDto kakaoTokenInfoDto = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(KAKAO_TOKEN_INFO_URL)
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(KakaoTokenInfoDto.class)
+                .block();
 
-            return kakaoTokenInfoDto.getExpiresIn() > 0;
-        } catch (WebClientException e) {
-            log.error("카카오 API 요청에 실패했습니다. accessToken: {}", accessToken);
-            throw new IllegalArgumentException("카카오 API 요청에 실패했습니다. accessToken: " + accessToken); // TODO 예외처리
-        }
+        return kakaoTokenInfoDto.getExpiresIn() > 0;
     }
 
     /**
-     * 요청에서 받은 카카오 accessToken을 이용해서 카카오 API서버에서 token에 해당하는 유저 ㅅ보를 얻어온다.
+     * 요청에서 받은 카카오 accessToken을 이용해서 카카오 API서버에서 token에 해당하는 유저 정보를 얻어온다.
      *
      * @param accessToken
      * @return OAuthUserInfoDto
      */
     public OAuthUserInfoDto getUserInfo(String accessToken) {
-        try {
-            KakaoUserInfoDto kakaoUserInfoDto = webClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path(KAKAO_USER_INFO_URL)
-                            .build())
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                    .retrieve()
-                    .bodyToMono(KakaoUserInfoDto.class)
-                    .block();
+        KakaoUserInfoDto kakaoUserInfoDto = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(KAKAO_USER_INFO_URL)
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(KakaoUserInfoDto.class)
+                .block();
 
-            return kakaoUserInfoDto.buildUserInfo();
-        } catch (WebClientException e) {
-            log.error("카카오 API 요청에 실패했습니다. accessToken: {}", accessToken);
-            throw new IllegalArgumentException("카카오 API 요청에 실패했습니다. accessToken: " + accessToken); // TODO 예외처리
-        }
+        return kakaoUserInfoDto.buildUserInfo();
     }
 }

--- a/src/main/java/com/yapp/betree/service/oauth/KakaoApiService.java
+++ b/src/main/java/com/yapp/betree/service/oauth/KakaoApiService.java
@@ -1,0 +1,82 @@
+package com.yapp.betree.service.oauth;
+
+import com.yapp.betree.dto.oauth.KakaoTokenInfoDto;
+import com.yapp.betree.dto.oauth.KakaoUserInfoDto;
+import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientException;
+
+@Service
+@Slf4j
+public class KakaoApiService {
+    private static final String KAPI_BASE_URL = "https://kapi.kakao.com";
+    private static final String KAKAO_TOKEN_INFO_URL = "/v1/user/access_token_info";
+    private static final String KAKAO_USER_INFO_URL = "/v2/user/me";
+
+    private final WebClient webClient;
+
+    public KakaoApiService() {
+        this.webClient = initWebClient(KAPI_BASE_URL);
+    }
+
+    public KakaoApiService(String apiUrl) {
+        this.webClient = initWebClient(apiUrl);
+    }
+
+    private WebClient initWebClient(String apiUrl) {
+        return WebClient.builder()
+                .baseUrl(apiUrl)
+                .build();
+    }
+
+    /**
+     * 요청에서 받은 카카오 accessToken을 이용해서 카카오 API서버에 토큰이 유효한지 검증한다.
+     *
+     * @param accessToken
+     * @return boolean
+     */
+    public boolean supports(String accessToken) {
+        try {
+            KakaoTokenInfoDto kakaoTokenInfoDto = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(KAKAO_TOKEN_INFO_URL)
+                            .build())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoTokenInfoDto.class)
+                    .block();
+
+            return kakaoTokenInfoDto.getExpiresIn() > 0;
+        } catch (WebClientException e) {
+            log.error("카카오 API 요청에 실패했습니다. accessToken: {}", accessToken);
+            throw new IllegalArgumentException("카카오 API 요청에 실패했습니다. accessToken: " + accessToken); // TODO 예외처리
+        }
+    }
+
+    /**
+     * 요청에서 받은 카카오 accessToken을 이용해서 카카오 API서버에서 token에 해당하는 유저 ㅅ보를 얻어온다.
+     *
+     * @param accessToken
+     * @return OAuthUserInfoDto
+     */
+    public OAuthUserInfoDto getUserInfo(String accessToken) {
+        try {
+            KakaoUserInfoDto kakaoUserInfoDto = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(KAKAO_USER_INFO_URL)
+                            .build())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfoDto.class)
+                    .block();
+
+            return kakaoUserInfoDto.buildUserInfo();
+        } catch (WebClientException e) {
+            log.error("카카오 API 요청에 실패했습니다. accessToken: {}", accessToken);
+            throw new IllegalArgumentException("카카오 API 요청에 실패했습니다. accessToken: " + accessToken); // TODO 예외처리
+        }
+    }
+}

--- a/src/main/java/com/yapp/betree/service/oauth/KakaoApiService.java
+++ b/src/main/java/com/yapp/betree/service/oauth/KakaoApiService.java
@@ -4,6 +4,7 @@ import com.yapp.betree.dto.oauth.KakaoTokenInfoDto;
 import com.yapp.betree.dto.oauth.KakaoUserInfoDto;
 import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -18,8 +19,9 @@ public class KakaoApiService {
 
     private final WebClient webClient;
 
+    @Autowired
     public KakaoApiService() {
-        this.webClient = initWebClient(KAPI_BASE_URL);
+        this(KAPI_BASE_URL);
     }
 
     public KakaoApiService(String apiUrl) {

--- a/src/main/java/com/yapp/betree/util/BetreeUtils.java
+++ b/src/main/java/com/yapp/betree/util/BetreeUtils.java
@@ -8,4 +8,8 @@ public class BetreeUtils {
     public static String makeUserAccessUrl(OAuthUserInfoDto user) {
         return "accessUrl";
     }
+
+    public static String makeUserAccessUrl(Long oauthId) {
+        return "accessUrl";
+    }
 }

--- a/src/main/java/com/yapp/betree/util/BetreeUtils.java
+++ b/src/main/java/com/yapp/betree/util/BetreeUtils.java
@@ -1,0 +1,11 @@
+package com.yapp.betree.util;
+
+import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
+
+public class BetreeUtils {
+
+    // TODO 유저 접속 URL 생성 필요
+    public static String makeUserAccessUrl(OAuthUserInfoDto user) {
+        return "accessUrl";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,3 +40,10 @@ server:
       force: true
     session:
       tracking-modes: COOKIE
+
+secrets:
+  jwt:
+    token:
+      secret-key: B1e2t3r4e5e6S7e8c9r0e1t
+      expiration-time: 600000
+      refresh-expiration-time: 86400000

--- a/src/test/java/com/yapp/betree/config/TestConfig.java
+++ b/src/test/java/com/yapp/betree/config/TestConfig.java
@@ -1,0 +1,23 @@
+package com.yapp.betree.config;
+
+import com.yapp.betree.service.oauth.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+    @Bean
+    public JwtTokenProvider jwtTokenProvider() {
+        return new JwtTokenProvider("secretKey", 6000L, 6000L) {
+            @Override
+            public Claims parseToken(String token) {
+                return Jwts.parser()
+                        .setSigningKey("secretKey")
+                        .parseClaimsJws(token)
+                        .getBody();
+            };
+        };
+    }
+}

--- a/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
@@ -1,0 +1,69 @@
+package com.yapp.betree.controller;
+
+import com.yapp.betree.domain.Folder;
+import com.yapp.betree.domain.FruitType;
+import com.yapp.betree.domain.User;
+import com.yapp.betree.dto.UserInfoFixture;
+import com.yapp.betree.repository.FolderRepository;
+import com.yapp.betree.repository.UserRepository;
+import com.yapp.betree.service.oauth.KakaoApiService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+public class AcceptanceTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FolderRepository folderRepository;
+
+    @MockBean
+    private KakaoApiService kakaoApiService;
+
+    @BeforeEach
+    void setUp(final WebApplicationContext webApplicationContext) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 테스트 - 유저 생성, 폴더 생성")
+    void signUpTest() throws Exception {
+        given(kakaoApiService.getOauthId("accessToken")).willReturn(1L);
+        given(kakaoApiService.getUserInfo("accessToken")).willReturn(UserInfoFixture.createOAuthUserInfo());
+
+        mockMvc.perform(get("/api/signin")
+                .header("X-Kakao-Access-Token", "accessToken"))
+                .andDo(print())
+                .andExpect(status().isCreated());
+
+        List<User> users = userRepository.findAll();
+        assertThat(users.get(0).getNickName()).isEqualTo("user");
+
+        List<Folder> folders = folderRepository.findAll();
+        assertThat(folders.get(0).getFruit()).isEqualTo(FruitType.DEFAULT);
+
+        assertThat(users.get(0).getFolders().get(0).getId()).isEqualTo(folders.get(0).getId());
+    }
+}

--- a/src/test/java/com/yapp/betree/controller/ControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/ControllerTest.java
@@ -1,0 +1,25 @@
+package com.yapp.betree.controller;
+
+import com.yapp.betree.config.TestConfig;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+@MockBean(classes = {JpaMetamodelMappingContext.class})
+@Import(value = TestConfig.class)
+public class ControllerTest {
+
+    /**
+     * ControllerTest extends해서
+     .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
+     헤더에 추가 필요
+     * @throws Exception
+     */
+//    @Test
+//    void Test() throws Exception {
+//        mockMvc.perform(get("/api/forest")
+//                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
+//                .andDo(print())
+//                .andExpect(status().isCreated());
+//    }
+}

--- a/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
@@ -21,8 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("OAuth 컨트롤러 테스트")
 @WebMvcTest(OAuthController.class)
-@MockBean(JpaMetamodelMappingContext.class)
-public class OAuthControllerTest {
+public class OAuthControllerTest extends ControllerTest{
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.reactive.function.client.WebClientException;
@@ -21,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("OAuth 컨트롤러 테스트")
 @WebMvcTest(OAuthController.class)
-public class OAuthControllerTest extends ControllerTest{
+public class OAuthControllerTest extends ControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
@@ -51,7 +51,7 @@ public class OAuthControllerTest {
 
         mockMvc.perform(get("/api/signin")
                 .header("X-Kakao-Access-Token", accessToken))
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("code").value("O002"))
                 .andDo(print());
     }
@@ -61,12 +61,12 @@ public class OAuthControllerTest {
     void oauthUserInfoInvalidTest() throws Exception {
         String accessToken = "accessToken";
         given(kakaoApiService.supports(accessToken)).willReturn(true);
-        given(kakaoApiService.getUserInfo(accessToken)).willThrow(new KakaoWebClientException("kakao"));
+        given(kakaoApiService.getUserInfo(accessToken)).willThrow(new KakaoWebClientException("401"));
 
         mockMvc.perform(get("/api/signin")
                 .header("X-Kakao-Access-Token", accessToken))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("code").value("C002"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("code").value("O000"))
                 .andDo(print());
     }
 

--- a/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
@@ -1,0 +1,78 @@
+package com.yapp.betree.controller;
+
+import com.yapp.betree.service.oauth.KakaoApiService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.reactive.function.client.WebClientException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("OAuth 컨트롤러 테스트")
+@WebMvcTest(OAuthController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+public class OAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private KakaoApiService kakaoApiService;
+
+    @Test
+    @DisplayName("MockMvc는 null이 아니다.")
+    void mvcIsNotNull() {
+        assertThat(mockMvc).isNotNull();
+    }
+
+    @Test
+    @DisplayName("회원가입,로그인 - 헤더에 AccessToken이 없으면 예외가 발생한다.")
+    void headerAccessTokenNullTest() throws Exception {
+        mockMvc.perform(get("/api/signin"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("C001"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원가입,로그인 - OAuth로 받아온 액세스 토큰이 만료되면 예외가 발생한다.")
+    void accessTokenExpiredTest() throws Exception {
+        String accessToken = "accessToken";
+        given(kakaoApiService.supports(accessToken)).willReturn(false);
+
+        mockMvc.perform(get("/api/signin")
+                .header("X-Kakao-Access-Token", accessToken))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("O002"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원가입,로그인 - OAuth API 요청에 실패하면 예외가 발생한다. ")
+    void oauthUserInfoInvalidTest() throws Exception {
+        String accessToken = "accessToken";
+        given(kakaoApiService.supports(accessToken)).willReturn(true);
+        given(kakaoApiService.getUserInfo(accessToken)).willThrow(new KakaoWebClientException("kakao"));
+
+        mockMvc.perform(get("/api/signin")
+                .header("X-Kakao-Access-Token", accessToken))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("code").value("C002"))
+                .andDo(print());
+    }
+
+    private static class KakaoWebClientException extends WebClientException {
+        public KakaoWebClientException(String msg) {
+            super(msg);
+        }
+    }
+}

--- a/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
@@ -1,6 +1,6 @@
 package com.yapp.betree.controller;
 
-import com.yapp.betree.service.oauth.KakaoApiService;
+import com.yapp.betree.service.LoginService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +26,7 @@ public class OAuthControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
-    private KakaoApiService kakaoApiService;
+    private LoginService loginService;
 
     @Test
     @DisplayName("MockMvc는 null이 아니다.")
@@ -44,24 +44,10 @@ public class OAuthControllerTest {
     }
 
     @Test
-    @DisplayName("회원가입,로그인 - OAuth로 받아온 액세스 토큰이 만료되면 예외가 발생한다.")
-    void accessTokenExpiredTest() throws Exception {
-        String accessToken = "accessToken";
-        given(kakaoApiService.supports(accessToken)).willReturn(false);
-
-        mockMvc.perform(get("/api/signin")
-                .header("X-Kakao-Access-Token", accessToken))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("code").value("O002"))
-                .andDo(print());
-    }
-
-    @Test
     @DisplayName("회원가입,로그인 - OAuth API 요청에 실패하면 예외가 발생한다. ")
     void oauthUserInfoInvalidTest() throws Exception {
         String accessToken = "accessToken";
-        given(kakaoApiService.supports(accessToken)).willReturn(true);
-        given(kakaoApiService.getUserInfo(accessToken)).willThrow(new KakaoWebClientException("401"));
+        given(loginService.createToken(accessToken)).willThrow(new KakaoWebClientException("401"));
 
         mockMvc.perform(get("/api/signin")
                 .header("X-Kakao-Access-Token", accessToken))

--- a/src/test/java/com/yapp/betree/domain/EntityTest.java
+++ b/src/test/java/com/yapp/betree/domain/EntityTest.java
@@ -25,7 +25,6 @@ public class EntityTest {
     @DisplayName("기본 DB 값 생성")
     @Test
     void createEntity() {
-
         User user = User.builder()
                 .nickName("user")
                 .email("user@user.com")

--- a/src/test/java/com/yapp/betree/domain/UserTest.java
+++ b/src/test/java/com/yapp/betree/domain/UserTest.java
@@ -1,0 +1,29 @@
+package com.yapp.betree.domain;
+
+import com.yapp.betree.util.BetreeUtils;
+import org.junit.jupiter.api.DisplayName;
+
+import java.time.LocalDateTime;
+
+@DisplayName("User 테스트")
+public class UserTest {
+
+    // save하기 전 테스트용 user (id는 null)
+    public static final User TEST_USER = User.builder()
+            .oauthId(1L)
+            .nickName("닉네임")
+            .email("email@email.com")
+            .userImage("default image uri")
+            .lastAccessTime(LocalDateTime.now())
+            .url(BetreeUtils.makeUserAccessUrl(1L))
+            .build();
+    public static final User TEST_SAVE_USER = User.builder()
+            .id(1L)
+            .oauthId(1L)
+            .nickName("닉네임")
+            .email("email@email.com")
+            .userImage("default image uri")
+            .lastAccessTime(LocalDateTime.now())
+            .url(BetreeUtils.makeUserAccessUrl(1L))
+            .build();
+}

--- a/src/test/java/com/yapp/betree/dto/KakaoTokenInfoFixture.java
+++ b/src/test/java/com/yapp/betree/dto/KakaoTokenInfoFixture.java
@@ -1,0 +1,25 @@
+package com.yapp.betree.dto;
+
+import com.yapp.betree.dto.oauth.KakaoTokenInfoDto;
+
+public class KakaoTokenInfoFixture {
+    private static final Long ID = 1L;
+    private static final Integer EXPIRES_IN = 20000;
+    private static final Integer APP_ID = 100;
+
+    public static KakaoTokenInfoDto createKakaoTokenInfoResponse() {
+        return KakaoTokenInfoDto.builder()
+                .id(1L)
+                .expiresIn(20000)
+                .appId(1)
+                .build();
+    }
+
+    public static KakaoTokenInfoDto createKakaoTokenInfoFailResponse() {
+        return KakaoTokenInfoDto.builder()
+                .id(1L)
+                .expiresIn(0)
+                .appId(1)
+                .build();
+    }
+}

--- a/src/test/java/com/yapp/betree/dto/UserInfoFixture.java
+++ b/src/test/java/com/yapp/betree/dto/UserInfoFixture.java
@@ -1,0 +1,34 @@
+package com.yapp.betree.dto;
+
+import com.yapp.betree.dto.oauth.KakaoAccountDto;
+import com.yapp.betree.dto.oauth.KakaoProfileDto;
+import com.yapp.betree.dto.oauth.KakaoUserInfoDto;
+import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
+
+public class UserInfoFixture {
+    private static final Long ID = 1L;
+    private static final String NICKNAME = "닉네임";
+    private static final String EMAIL = "email@email.com";
+
+    public static OAuthUserInfoDto createOAuthUserInfo() {
+        return OAuthUserInfoDto.builder()
+                .id(ID)
+                .nickname(NICKNAME)
+                .email(EMAIL)
+                .build();
+    }
+
+    public static KakaoUserInfoDto createKakaoUserInfoResponse() {
+        return KakaoUserInfoDto.builder()
+                .id(ID)
+                .kakaoAccount(new KakaoAccountDto(new KakaoProfileDto(NICKNAME), EMAIL))
+                .build();
+    }
+
+    public static KakaoUserInfoDto createKakaoUserInfoFailResponse() {
+        return KakaoUserInfoDto.builder()
+                .id(ID)
+                .kakaoAccount(new KakaoAccountDto(new KakaoProfileDto(NICKNAME), null))
+                .build();
+    }
+}

--- a/src/test/java/com/yapp/betree/interceptor/ArgumentResolverTest.java
+++ b/src/test/java/com/yapp/betree/interceptor/ArgumentResolverTest.java
@@ -1,0 +1,50 @@
+package com.yapp.betree.interceptor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.yapp.betree.dto.LoginUserDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.yapp.betree.domain.UserTest.TEST_SAVE_USER;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LoginUser생성 아규먼트 리졸버 테스트")
+public class ArgumentResolverTest {
+    private UserHandlerMethodArgumentResolver userHandlerMethodArgumentResolver;
+
+
+    @BeforeEach
+    void setUp() {
+        userHandlerMethodArgumentResolver = new testArgumentResolver();
+    }
+
+    @Test
+    @DisplayName("아규먼트 리졸버가 로그인 유저를 반환한다.")
+    void argumentResolverTest() throws JsonProcessingException {
+        LoginUserDto user = (LoginUserDto) userHandlerMethodArgumentResolver.resolveArgument(null, null, null, null);
+
+        Assertions.assertThat(user.getId()).isEqualTo(TEST_SAVE_USER.getId());
+        Assertions.assertThat(user.getEmail()).isEqualTo(TEST_SAVE_USER.getEmail());
+        Assertions.assertThat(user.getNickname()).isEqualTo(TEST_SAVE_USER.getNickName());
+    }
+
+    static class testArgumentResolver extends UserHandlerMethodArgumentResolver {
+        @Override
+        public boolean supportsParameter(MethodParameter parameter) {
+            return true;
+        }
+
+        @Override
+        public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws JsonProcessingException {
+            return LoginUserDto.of(TEST_SAVE_USER);
+        }
+    }
+}

--- a/src/test/java/com/yapp/betree/interceptor/TokenInterceptorTest.java
+++ b/src/test/java/com/yapp/betree/interceptor/TokenInterceptorTest.java
@@ -1,0 +1,68 @@
+package com.yapp.betree.interceptor;
+
+import com.yapp.betree.domain.UserTest;
+import com.yapp.betree.dto.LoginUserDto;
+import com.yapp.betree.dto.oauth.JwtTokenDto;
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.service.JwtTokenTest;
+import com.yapp.betree.service.oauth.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+@SpringBootTest
+@DisplayName("토큰 검증 인터셉터 테스트")
+public class TokenInterceptorTest {
+
+    private TokenInterceptor tokenInterceptor;
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        this.jwtTokenProvider = JwtTokenTest.JWT_PROVIDER;
+        this.tokenInterceptor = new TokenInterceptor(jwtTokenProvider);
+    }
+
+    @Test
+    @DisplayName("헤더에 Authorization이 존재하지 않으면 예외가 발생한다")
+    void headerFailTest() throws Exception {
+        assertThatThrownBy(() ->
+                tokenInterceptor.preHandle(new MockHttpServletRequest(), null, null))
+                .isInstanceOf(BetreeException.class)
+                .hasMessageContaining("헤더에 토큰이 존재하지 않습니다.");
+
+    }
+
+    @Test
+    @DisplayName("토큰 파싱에 실패하면 예외가 발생한다.")
+    void headerTokenParseFailTest() {
+        jwtTokenProvider = new JwtTokenProvider("anotherSecretKey", 0L, 0L);
+        JwtTokenDto token = jwtTokenProvider.createToken(LoginUserDto.of(UserTest.TEST_SAVE_USER));
+
+        assertThatThrownBy(() ->
+                tokenInterceptor.preHandle(jwtAuthHttpRequest(token.getAccessToken()), null, null))
+                .isInstanceOf(BetreeException.class)
+                .hasMessageContaining("토큰 파싱에 실패했습니다.");
+    }
+
+    @Test
+    @DisplayName("토큰 검증 성공시 인터셉터가 true를 반환한다.")
+    void claimAttributeTest() throws Exception {
+        JwtTokenDto token = jwtTokenProvider.createToken(LoginUserDto.of(UserTest.TEST_SAVE_USER));
+
+        assertThat(tokenInterceptor.preHandle(jwtAuthHttpRequest(token.getAccessToken()), null, null)).isTrue();
+    }
+
+    private MockHttpServletRequest jwtAuthHttpRequest(String token) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        return request;
+    }
+}

--- a/src/test/java/com/yapp/betree/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/yapp/betree/repository/FolderRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.yapp.betree.repository;
+
+import com.yapp.betree.domain.Folder;
+import com.yapp.betree.domain.FruitType;
+import com.yapp.betree.domain.User;
+import com.yapp.betree.domain.UserTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@DisplayName("Folder Repository 테스트")
+public class FolderRepositoryTest {
+
+    @Autowired
+    private FolderRepository folderRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("유저와 폴더 함께 생성")
+    void folderUserSaveTest() {
+        User user = UserTest.TEST_USER;
+        Folder folder = Folder.builder()
+                .fruit(FruitType.DEFAULT)
+                .level(0L)
+                .name("DEFAULT")
+                .build();
+        user.addFolder(folder);
+        userRepository.save(user);
+
+        List<Folder> folders = folderRepository.findAll();
+        assertThat(folders).hasSize(1);
+
+        List<User> users = userRepository.findAll();
+        assertThat(users).hasSize(1);
+    }
+}
+
+

--- a/src/test/java/com/yapp/betree/repository/UserRepositoryTest.java
+++ b/src/test/java/com/yapp/betree/repository/UserRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.yapp.betree.repository;
+
+import com.yapp.betree.domain.User;
+import com.yapp.betree.dto.UserInfoFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@DisplayName("UserRepository 테스트")
+public class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("findByOauthId 테스트")
+    void findByOauthIdTest() {
+        // given
+        User user = UserInfoFixture.createOAuthUserInfo().generateSignUpUser();
+        // when
+        userRepository.save(user);
+
+        // then
+        Optional<User> userByOauthId = userRepository.findByOauthId(user.getOauthId());
+        assertThat(userByOauthId).isPresent();
+        assertThat(userByOauthId.get().getNickName()).isEqualTo(user.getNickName());
+    }
+}

--- a/src/test/java/com/yapp/betree/service/JwtTokenTest.java
+++ b/src/test/java/com/yapp/betree/service/JwtTokenTest.java
@@ -1,0 +1,73 @@
+package com.yapp.betree.service;
+
+import com.yapp.betree.dto.LoginUserDto;
+import com.yapp.betree.dto.oauth.JwtTokenDto;
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.service.oauth.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.yapp.betree.domain.UserTest.TEST_SAVE_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Jwt 토큰 관련 테스트")
+public class JwtTokenTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProvider("secretKey", 600000L, 864000000L);
+    }
+
+    @Test
+    @DisplayName("유저 엔티티를 이용해서 jwt토큰을 생성한다.")
+    void createTokenTest() {
+        // given
+        JwtTokenDto tokenDto = jwtTokenProvider.createToken(LoginUserDto.of(TEST_SAVE_USER));
+
+        // when
+        Claims accessTokenClaims = jwtTokenProvider.parseToken(tokenDto.getAccessToken());
+
+        // then
+        assertThat(String.valueOf(accessTokenClaims.get("id"))).isEqualTo(String.valueOf(TEST_SAVE_USER.getId()));
+        assertThat(accessTokenClaims.get("nickname")).isEqualTo(TEST_SAVE_USER.getNickName());
+        assertThat(accessTokenClaims.get("email")).isEqualTo(TEST_SAVE_USER.getEmail());
+    }
+
+    @Test
+    @DisplayName("jwt 토큰 만료시 예외가 발생한다.")
+    void expiredTokenTest() {
+        jwtTokenProvider = new JwtTokenProvider("secretKey", 0L, 0L);
+        JwtTokenDto tokenDto = jwtTokenProvider.createToken(LoginUserDto.of(TEST_SAVE_USER));
+
+        assertThatThrownBy(() -> jwtTokenProvider.parseToken(tokenDto.getAccessToken()))
+                .isInstanceOf(BetreeException.class)
+                .hasMessageContaining("만료");
+
+        assertThatThrownBy(() -> jwtTokenProvider.parseToken(tokenDto.getRefreshToken()))
+                .isInstanceOf(BetreeException.class)
+                .hasMessageContaining("만료");
+    }
+
+    @Test
+    @DisplayName("JWT 파싱시 기타 예외처리 테스트 - secretKey가 다를 경우 예외가 발생한다.")
+    void jwtExceptionTest() {
+        // given
+        JwtTokenDto tokenDto = jwtTokenProvider.createToken(LoginUserDto.of(TEST_SAVE_USER));
+
+        // when
+        jwtTokenProvider = new JwtTokenProvider("anotherKey", 0L, 0L);
+
+        // then
+        assertThatThrownBy(() -> jwtTokenProvider.parseToken(tokenDto.getAccessToken()))
+                .isInstanceOf(BetreeException.class)
+                .hasMessageContaining("토큰 파싱에 실패했습니다.");
+    }
+}

--- a/src/test/java/com/yapp/betree/service/JwtTokenTest.java
+++ b/src/test/java/com/yapp/betree/service/JwtTokenTest.java
@@ -25,17 +25,19 @@ public class JwtTokenTest {
     public static final String JWT_TOKEN_TEST = Jwts.builder()
             .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
             .signWith(SignatureAlgorithm.HS256, "secretKey")
-            .claim("id","1")
-            .claim("nickname","닉네임")
-            .claim("email","email@email.com")
+            .claim("id", "1")
+            .claim("nickname", "닉네임")
+            .claim("email", "email@email.com")
             .compact();
+
+    public static final JwtTokenProvider JWT_PROVIDER = new JwtTokenProvider("secretKey", 600000L, 864000000L);
 
 
     private JwtTokenProvider jwtTokenProvider;
 
     @BeforeEach
     void setUp() {
-        jwtTokenProvider = new JwtTokenProvider("secretKey", 600000L, 864000000L);
+        jwtTokenProvider = JWT_PROVIDER;
     }
 
     @Test

--- a/src/test/java/com/yapp/betree/service/JwtTokenTest.java
+++ b/src/test/java/com/yapp/betree/service/JwtTokenTest.java
@@ -5,6 +5,9 @@ import com.yapp.betree.dto.oauth.JwtTokenDto;
 import com.yapp.betree.exception.BetreeException;
 import com.yapp.betree.service.oauth.JwtTokenProvider;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +21,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Jwt 토큰 관련 테스트")
 public class JwtTokenTest {
+
+    public static final String JWT_TOKEN_TEST = Jwts.builder()
+            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+            .signWith(SignatureAlgorithm.HS256, "secretKey")
+            .claim("id","1")
+            .claim("nickname","닉네임")
+            .claim("email","email@email.com")
+            .compact();
+
 
     private JwtTokenProvider jwtTokenProvider;
 

--- a/src/test/java/com/yapp/betree/service/KakaoApiServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/KakaoApiServiceTest.java
@@ -1,0 +1,110 @@
+package com.yapp.betree.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.yapp.betree.dto.oauth.KakaoTokenInfoDto;
+import com.yapp.betree.dto.oauth.KakaoUserInfoDto;
+import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
+import com.yapp.betree.service.oauth.KakaoApiService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+
+import static com.yapp.betree.dto.KakaoTokenInfoFixture.createKakaoTokenInfoFailResponse;
+import static com.yapp.betree.dto.KakaoTokenInfoFixture.createKakaoTokenInfoResponse;
+import static com.yapp.betree.dto.UserInfoFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("카카오 외부 api 요청 mock 테스트")
+public class KakaoApiServiceTest {
+
+    private static MockWebServer mockWebServer;
+    private static ObjectMapper objectMapper;
+
+    private KakaoApiService kakaoApiService;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        objectMapper = new ObjectMapper();
+        mockWebServer = new MockWebServer();
+        mockWebServer.play();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @BeforeEach
+    void initialize() {
+        String baseUrl = String.format("http://localhost:%s",
+                mockWebServer.getPort());
+        kakaoApiService = new KakaoApiService(baseUrl);
+    }
+
+    @Test
+    @DisplayName("카카오 토큰 유효 검증 - expiresIn값이 양수이면 유효한 토큰이다.")
+    void supportsTest() throws Exception {
+        KakaoTokenInfoDto kakaoTokenInfoDto = createKakaoTokenInfoResponse();
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(kakaoTokenInfoDto))
+                .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
+
+        assertThat(kakaoApiService.supports("accessToken")).isTrue();
+    }
+
+    @Test
+    @DisplayName("카카오 토큰 유효 검증 - expiresIn값이 0이하이면 유효하지 않은 토큰이다.")
+    void supportsFailTest() throws Exception {
+        KakaoTokenInfoDto kakaoTokenInfoDto = createKakaoTokenInfoFailResponse();
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(kakaoTokenInfoDto))
+                .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
+
+        assertThat(kakaoApiService.supports("accessToken")).isFalse();
+    }
+
+    @Test
+    @DisplayName("카카오 유저 정보 요청 - 토큰으로 유저정보를 얻어올 수 있다.")
+    void getUserInfoTest() throws Exception {
+        KakaoUserInfoDto kakaoUserInfo = createKakaoUserInfoResponse();
+        OAuthUserInfoDto oAuthUserInfo = createOAuthUserInfo();
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(kakaoUserInfo))
+                .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
+
+
+        OAuthUserInfoDto userInfo = kakaoApiService.getUserInfo("accessToken");
+        assertThat(userInfo.getId()).isEqualTo(oAuthUserInfo.getId());
+        assertThat(userInfo.getNickname()).isEqualTo(oAuthUserInfo.getNickname());
+        assertThat(userInfo.getEmail()).isEqualTo(oAuthUserInfo.getEmail());
+    }
+
+    @Test
+    @DisplayName("카카오 유저 정보 요청 - 유저정보 이메일에 빈 값이 있으면 예외가 발생한다.")
+    void getUserInfoFailTest() throws Exception {
+        KakaoUserInfoDto kakaoUserInfo = createKakaoUserInfoFailResponse();
+        OAuthUserInfoDto oAuthUserInfo = createOAuthUserInfo();
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(kakaoUserInfo))
+                .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
+
+        assertThatThrownBy(()->kakaoApiService.getUserInfo("accessToken"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("email");
+    }
+}

--- a/src/test/java/com/yapp/betree/service/KakaoApiServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/KakaoApiServiceTest.java
@@ -6,6 +6,7 @@ import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.yapp.betree.dto.oauth.KakaoTokenInfoDto;
 import com.yapp.betree.dto.oauth.KakaoUserInfoDto;
 import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
+import com.yapp.betree.exception.BetreeException;
 import com.yapp.betree.service.oauth.KakaoApiService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -103,8 +104,8 @@ public class KakaoApiServiceTest {
                 .setBody(objectMapper.writeValueAsString(kakaoUserInfo))
                 .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
 
-        assertThatThrownBy(()->kakaoApiService.getUserInfo("accessToken"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("email");
+        assertThatThrownBy(() -> kakaoApiService.getUserInfo("accessToken"))
+                .isInstanceOf(BetreeException.class)
+                .hasMessageContaining("email is null");
     }
 }

--- a/src/test/java/com/yapp/betree/service/KakaoApiServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/KakaoApiServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 
@@ -32,6 +33,7 @@ public class KakaoApiServiceTest {
     private static MockWebServer mockWebServer;
     private static ObjectMapper objectMapper;
 
+    @InjectMocks
     private KakaoApiService kakaoApiService;
 
     @BeforeAll
@@ -54,7 +56,7 @@ public class KakaoApiServiceTest {
     }
 
     @Test
-    @DisplayName("카카오 토큰 유효 검증 - expiresIn값이 양수이면 유효한 토큰이다.")
+    @DisplayName("카카오 토큰 유효 검증 - API호출이 성공하고 expiresIn값이 양수이면 유저 OAuthId를 반환한다.")
     void supportsTest() throws Exception {
         KakaoTokenInfoDto kakaoTokenInfoDto = createKakaoTokenInfoResponse();
 
@@ -62,11 +64,11 @@ public class KakaoApiServiceTest {
                 .setBody(objectMapper.writeValueAsString(kakaoTokenInfoDto))
                 .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
 
-        assertThat(kakaoApiService.supports("accessToken")).isTrue();
+        assertThat(kakaoApiService.getOauthId("accessToken")).isEqualTo(1L);
     }
 
     @Test
-    @DisplayName("카카오 토큰 유효 검증 - expiresIn값이 0이하이면 유효하지 않은 토큰이다.")
+    @DisplayName("카카오 토큰 유효 검증 - API호출이 성공하고 expiresIn값이 음수이면 예외가 발생한다.")
     void supportsFailTest() throws Exception {
         KakaoTokenInfoDto kakaoTokenInfoDto = createKakaoTokenInfoFailResponse();
 
@@ -74,7 +76,9 @@ public class KakaoApiServiceTest {
                 .setBody(objectMapper.writeValueAsString(kakaoTokenInfoDto))
                 .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
 
-        assertThat(kakaoApiService.supports("accessToken")).isFalse();
+        assertThatThrownBy(() -> kakaoApiService.getOauthId("accessToken"))
+                .isInstanceOf(BetreeException.class)
+                .hasMessageContaining("accessToken");
     }
 
     @Test

--- a/src/test/java/com/yapp/betree/service/UserServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/UserServiceTest.java
@@ -1,0 +1,55 @@
+package com.yapp.betree.service;
+
+import com.yapp.betree.domain.User;
+import com.yapp.betree.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.yapp.betree.domain.UserTest.TEST_SAVE_USER;
+import static com.yapp.betree.domain.UserTest.TEST_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 테스트")
+public class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("oauthId를 통해 User를 얻어낼 수 있다.")
+    void findByOauthIdTest() {
+        // given
+        given(userRepository.findByOauthId(TEST_USER.getOauthId())).willReturn(Optional.of(TEST_SAVE_USER));
+
+        // when
+        Optional<User> byOauthId = userService.findByOauthId(TEST_USER.getOauthId());
+
+        // then
+        assertThat(byOauthId).isPresent();
+        assertThat(byOauthId.get().getId()).isEqualTo(TEST_SAVE_USER.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 oauthId로 조회 테스트")
+    void findByOauthIdFailTest() {
+        // given
+        given(userRepository.findByOauthId(TEST_USER.getOauthId())).willReturn(Optional.empty());
+
+        // when
+        Optional<User> byOauthId = userService.findByOauthId(TEST_USER.getOauthId());
+
+        // then
+        assertThat(byOauthId).isEmpty();
+    }
+}


### PR DESCRIPTION
## 이슈
- #14 

## 작업 내용
- [x]  토큰으로 유저 정보 획득 (토큰 header에 담아 요청) - `예외처리 완료`
  - OAuth 요청시 문제 생기면 `400` or `500` 에러 반환
  - 액세스 토큰 만료됐을때 카카오 자체에서 `401 Unauthorized from GET https://kapi.kakao.com/v1/user/access_token_info` 에러 생성됨 -> `500 Internal Server Error로 반환`
  - 유저정보 획득시 id, 이름, 이메일 3개 다 얻어와야함
    - [x] 비즈앱 등록해서 이메일 필수 설정 필요 
- [x] DB에서 id로 조회해와서 회원가입 유무 확인 -> 이때 조회하는 id는 oauthId
  - [x]  회원아니라면 회원가입+기본폴더생성 -> User-Folder User에 cascade설정 걸고 user.addFolder메서드로 연관관계 지정 
- [x] jwt토큰 발급 로그인 완료
  - accessToken 유효기간 1시간, refreshToken 일주일 
  - accessToken에는 LoginUserDto(id, 닉네임, 이메일)정보 claim에 담고 refreshToken에는 id만 담음 
  - accessToken은 Authorization header (Bearer형식)으로 전달, refreshToken은 httpOnly cookie로 설정
- [x] 이후 요청에서 jwt 토큰 검증 처리
  - `/api/signin` ,`/api/refresh-token`제외 전부 확인 -> 나중에 비로그인유저도 요청할수있는 api 추가로 except 설정 해줘야함
  - 인터셉터에서 Authorization header가 있는지 확인 
  - 토큰이 유효한지 확인
  - 유효하다면 ArgumentResolver에서 사용하기 위한 유저정보 reqeuest.setattribute로 설정해줌 
- [x] jwt토큰으로 로그인 사용자 정보 얻어오기 
  - argumentResolver로 `@LoginUser`어노테이션이 붙은 파라미터로 LoginUserDto정보 전달 

## 기타 사항
- 예외처리
- WebClient 사용
- WebClient 테스트 코드 작성을 위해 WebMockServer 사용 (외부 API 연동 테스트)
- 테스트코드에 public static final로 Fixture데이터(테스트용 데이터)만들어서 사용중
- `@WebMvcTest`로 하는 컨트롤러 단위테스트에서는 `TestConfig` 설정클래스 이용해서 jwtProvider mock처리 필요 
- 인터셉터, 리졸버 테스트는 따로 했으니 나중에 통합테스트할때는 mock 처리해서 사용해도 될듯(given..)
- 스웨거에서 Authorize 버튼에 `Bearer 토큰` 입력하면 일괄적으로 api요청 헤더에 accessToken 입력할 수 있음

## 참고 
- 프론트엔드 토큰발급할때 사용한 코드 
  - https://github.com/warnus/react-kakao-login-example.git
- 로그인 구현 및 테스트 참고 github
  - [https://github.com/teco-market/teco-market](https://github.com/teco-market/teco-market)
  - https://github.com/woowacourse-teams/2020-14f-guys/blob/9ae16b690c4cf5ef2831f297ad6eade5d9165872/src/main/java/com/woowacourse/pelotonbackend/infra/login/KakaoAPIService.java
  - https://github.com/depromeet/um-api/commit/143ac6a4cdf7b8e3eaa64728169041e50c9f3122#diff-2d585745a320473c2aeef8f5b76d233baedfb5366c484315bf6e5587e07b7065
- 외부 API 테스트관련
  -  [외부 API를 어떻게 테스트할것인가?](https://velog.io/@kyle/%EC%99%B8%EB%B6%80-API%EB%A5%BC-%EC%96%B4%EB%96%BB%EA%B2%8C-%ED%85%8C%EC%8A%A4%ED%8A%B8-%ED%95%A0-%EA%B2%83%EC%9D%B8%EA%B0%80)
  - [외부 API 연동 테스트 코드 @RestClientTest](https://cobbybb.tistory.com/24)
- WebClient
  - https://www.baeldung.com/spring-5-webclient
  - [@ResClientTest를 WebClient에서 사용하기](https://skyblue300a.tistory.com/11)
  - [공식문서](https://docs.spring.io/spring-framework/docs/5.2.6.RELEASE/spring-framework-reference/web-reactive.html#webflux-client-testing)
  - https://www.baeldung.com/spring-mocking-webclient 

- jwt토큰 생성
  - https://shinsunyoung.tistory.com/110
  - https://kukekyakya.tistory.com/entry/Spring-boot-access-token-refresh-token-%EB%B0%9C%EA%B8%89%EB%B0%9B%EA%B8%B0jwt
  - refreshtoken관련
     - https://llshl.tistory.com/m/32
- 스웨거에 토큰 헤더 설정 (SecurtyContext, SecurityScheme)  
  - https://www.baeldung.com/spring-boot-swagger-jwt
  - http://www.praconfi.com/2021-11-25/swagger-(+-spring-security,-jwt-)
- 토큰 쿠키, 헤더 값 설정 관련
  -   https://velog.io/@myway00/%EC%8A%A4%ED%94%84%EB%A7%81%EB%B6%80%ED%8A%B8-%EB%A6%AC%EC%95%A1%ED%8A%B8-jwt-%ED%86%A0%ED%81%B0-%EC%84%A4%EC%A0%95%EB%B0%A9%EB%B2%95
- 알규먼트 리졸버 
 - https://sanghye.tistory.com/41
 - 테스트코드 https://dadadamarine.github.io/java/spring/2019/04/26/spring-controller-test3.html

## TODO
- refreshToken 레디스 적용 (아주나중에)
- 코드 정리, 리팩토링
- 문서 정리
- 프론트엔드에 swagger 사용법 정리 
## 체크리스트
- [ ] example