### PR TITLE
전역 예외 처리 #16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     //Swagger
     implementation "io.springfox:springfox-boot-starter:3.0.0"
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '2.5.2'
+    implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/yapp/betree/exception/BetreeException.java
+++ b/src/main/java/com/yapp/betree/exception/BetreeException.java
@@ -1,0 +1,25 @@
+package com.yapp.betree.exception;
+
+public class BetreeException extends RuntimeException {
+
+    private final ErrorCode code;
+
+    @Override
+    public String getMessage() {
+        return super.getMessage();
+    }
+
+    public ErrorCode getCode() {
+        return this.code;
+    }
+
+    public BetreeException(ErrorCode code) {
+        super(code.getMessage());
+        this.code = code;
+    }
+
+    public BetreeException(ErrorCode code, String message) {
+        super(code.getMessage() + ": " + message);
+        this.code = code;
+    }
+}

--- a/src/main/java/com/yapp/betree/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/betree/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.yapp.betree.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT_VALUE(400, "C001", "Invalid input value"),
+    INTERNAL_SERVER_ERROR(500, "C002", "Internal server error"),
+    METHOD_NOT_ALLOWED(405, "C003", "Method not allowed"),
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/yapp/betree/exception/ErrorResponse.java
+++ b/src/main/java/com/yapp/betree/exception/ErrorResponse.java
@@ -1,0 +1,58 @@
+package com.yapp.betree.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.springframework.validation.FieldError;
+
+import javax.validation.ConstraintViolation;
+import java.util.List;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+    private int status;
+    private String code;
+    private String message;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<ValidationError> errors;
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    public static class ValidationError {
+        private final String field;
+        private final String value;
+        private final String message;
+
+        public static ValidationError of(FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .value(String.valueOf(fieldError.getRejectedValue()))
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+
+        public static ValidationError of(ConstraintViolation violation) {
+            return ValidationError.builder()
+                    .field(String.valueOf(violation.getPropertyPath()))
+                    .value(String.valueOf(violation.getInvalidValue()))
+                    .message(violation.getMessageTemplate())
+                    .build();
+        }
+    }
+
+    @Builder
+    public ErrorResponse(int status, String code, String message, List<ValidationError> errors) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.errors = errors;
+    }
+}

--- a/src/main/java/com/yapp/betree/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yapp/betree/exception/GlobalExceptionHandler.java
@@ -1,0 +1,84 @@
+package com.yapp.betree.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(value = BetreeException.class)
+    public ResponseEntity<ErrorResponse> handleBetreeException(BetreeException e) {
+        ErrorResponse er = getErrorResponse(e.getMessage(), e.getCode());
+        log.error("handleBetreeException[{}]", er);
+        return ResponseEntity
+                .status(e.getCode().getStatus())
+                .body(er);
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        ErrorResponse er = getErrorResponse(e, errorCode);
+        log.error("handleValidationException[{}]", er);
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(er);
+    }
+
+    @ExceptionHandler(value = ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        ErrorResponse er = getErrorResponse(e, errorCode);
+        log.error("ConstraintViolationException[{}]", er);
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(er);
+    }
+
+    public static ErrorResponse getErrorResponse(String message, ErrorCode code) {
+        return ErrorResponse.builder()
+                .code(code.getCode())
+                .message(message)
+                .status(code.getStatus())
+                .build();
+    }
+
+    public static ErrorResponse getErrorResponse(BindException e, ErrorCode code) {
+
+        List<ErrorResponse.ValidationError> validationErrorList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ErrorResponse.ValidationError::of)
+                .collect(Collectors.toList());
+
+        return ErrorResponse.builder()
+                .code(code.getCode())
+                .message(code.getMessage())
+                .errors(validationErrorList)
+                .status(code.getStatus())
+                .build();
+    }
+
+    public static ErrorResponse getErrorResponse(ConstraintViolationException e, ErrorCode code) {
+
+        List<ErrorResponse.ValidationError> validationErrorList = e.getConstraintViolations()
+                .stream()
+                .map(ErrorResponse.ValidationError::of)
+                .collect(Collectors.toList());
+
+        return ErrorResponse.builder()
+                .code(code.getCode())
+                .message(code.getMessage())
+                .errors(validationErrorList)
+                .status(code.getStatus())
+                .build();
+    }
+}


### PR DESCRIPTION
## 이슈
- #16 

## 작업 내용
- 커스텀 예외 생성
- 에러 코드, 에러 응답DTO 생성
- 전역예외핸들러 생성

## 기타 사항
- 에러코드 HttpStatus vs int status 뭐로 사용하는게 좋을까요 ?? 
- 사용방법
```java
throw new BetreeException(ErrorCode.XXX, "추가로 적을 메시지 있으면 적으면 됩니다.");
```
- 반환값 예시
```json
{
  "status": 400,
  "code": "C001",
  "message": "Invalid input value : treeId는 null일 수 없습니다."
}
```
```json
// 나중에 Validation하게됐을때 errors 반환 형식 예시 
{
  "status": 400,
  "code": "C001",
  "message": "Invalid input value",
  "errors": [
    {
      "field": "ranking",
      "value": "-1",
      "message": "순위를 올바르게 입력해주세요.(숫자 1이상)"
    },
    {
      "field": "ordinalNum",
      "value": "-1",
      "message": "대회 번호를 올바르게 입력해주세요. (숫자 1이상)"
    }
  ]
}
```

## 체크리스트
- [ ] example