### PR TITLE
fix: 폴더 글자수 제한 10자로 수정

### DIFF
--- a/src/main/java/com/yapp/betree/dto/request/TreeRequestDto.java
+++ b/src/main/java/com/yapp/betree/dto/request/TreeRequestDto.java
@@ -18,7 +18,7 @@ import javax.validation.constraints.NotBlank;
 public class TreeRequestDto {
 
     @NotBlank(message = "나무 이름은 빈값일 수 없습니다.")
-    @Length(max = 20, message = "나무 이름은 20자를 넘을 수 없습니다.")
+    @Length(max = 10, message = "나무 이름은 10자를 넘을 수 없습니다.")
     private String name;
 
     private FruitType fruitType;

--- a/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
@@ -161,6 +161,7 @@ public class ForestControllerTest extends ControllerTest {
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("C001"))
+                .andExpect(jsonPath("$.errors[0].message").value("나무 이름은 10자를 넘을 수 없습니다."))
                 .andDo(print());
     }
 

--- a/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
@@ -115,7 +115,7 @@ public class ForestControllerTest extends ControllerTest {
     void createTreeTest() throws Exception {
         // given
         Map<String, Object> input = new HashMap<>();
-        input.put("name", "update folder");
+        input.put("name", "추가폴더이름");
         input.put("fruitType", FruitType.APPLE);
 
         // when
@@ -135,7 +135,7 @@ public class ForestControllerTest extends ControllerTest {
     void createTreeEnumTest() throws Exception {
         // given
         Map<String, Object> input = new HashMap<>();
-        input.put("name", "update folder");
+        input.put("name", "추가폴더이름");
         input.put("fruitType", FruitType.DEFAULT);
 
         mockMvc.perform(post("/api/forest")
@@ -147,12 +147,12 @@ public class ForestControllerTest extends ControllerTest {
                 .andDo(print());
     }
 
-    @DisplayName("나무 추가 - 나무 이름은 20자를 넘을 수 없다.")
+    @DisplayName("나무 추가 - 나무 이름은 10자를 넘을 수 없다.")
     @Test
     void createTreeNameTest() throws Exception {
         // given
         Map<String, Object> input = new HashMap<>();
-        input.put("name", "update folder over length limit");
+        input.put("name", "10자 이상 폴더 이름");
         input.put("fruitType", FruitType.DEFAULT);
 
         mockMvc.perform(post("/api/forest")
@@ -186,7 +186,7 @@ public class ForestControllerTest extends ControllerTest {
     void updateTreeTest() throws Exception {
         // given
         Map<String, Object> input = new HashMap<>();
-        input.put("name", "update folder");
+        input.put("name", "변경폴더10자이내");
         input.put("fruitType", FruitType.APPLE);
 
         mockMvc.perform(put("/api/forest/18")
@@ -203,7 +203,7 @@ public class ForestControllerTest extends ControllerTest {
     void updateTreeDefaultTest() throws Exception {
         // given
         Map<String, Object> input = new HashMap<>();
-        input.put("name", "update folder");
+        input.put("name", "변경폴더이름");
         input.put("fruitType", FruitType.DEFAULT);
 
         willThrow(new BetreeException(ErrorCode.TREE_DEFAULT_ERROR, "변경할 타입을 기본 나무 이외의 다른 나무로 선택해주세요. treeId = " + 18 + ", FruitType = " + FruitType.DEFAULT))
@@ -219,12 +219,12 @@ public class ForestControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("T002"));
     }
 
-    @DisplayName("나무 편집 - 나무 이름은 20자를 넘을 수 없다.")
+    @DisplayName("나무 편집 - 나무 이름은 10자를 넘을 수 없다.")
     @Test
     void updateTreeNameTest() throws Exception {
         // given
         Map<String, Object> input = new HashMap<>();
-        input.put("name", "update folder over length limit");
+        input.put("name", "수정폴더이름10자이상ㅇㅇ");
         input.put("fruitType", FruitType.DEFAULT);
 
         mockMvc.perform(put("/api/forest/18")


### PR DESCRIPTION
## 이슈
- #29 

## 작업 내용
- 폴더이름길이 제한 20자->10자로 변경

## 기타 사항
- TreeRequestDto 어노테이션 수정
- 20자 기준이었던 테스트코드 10자로 변경해서 성공하도록 수정 
- 폴더 관련해서 유저회원가입 및 기본폴더 생성 테스트 DB 값에 영향없도록 수정 

## 체크리스트
- [x] 폴더관련 테스트코드 성공 확인

간단한수정인것 같아서 확인하시고 별 문제 없으면 바로 머지 부탁드릴게요!