### PR TITLE
fix: 메세지 dto에 작성일자/시간 추가

### DIFF
--- a/src/main/java/com/yapp/betree/dto/response/MessageBoxResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessageBoxResponseDto.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.time.LocalDateTime;
+
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,6 +25,7 @@ public class MessageBoxResponseDto {
     private boolean opening;
     private String senderNickname;
     private String senderProfileImage;
+    private LocalDateTime createdDate;
 
     @Builder
     public MessageBoxResponseDto(Message message, String senderNickname, String senderProfileImage) {
@@ -34,6 +37,7 @@ public class MessageBoxResponseDto {
         this.opening = message.isOpening();
         this.senderNickname = senderNickname;
         this.senderProfileImage = senderProfileImage;
+        this.createdDate= message.getCreatedDate();
     }
 
     public static MessageBoxResponseDto of(Message message, SendUserDto user) {

--- a/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
@@ -186,7 +186,7 @@ public class AcceptanceTest {
 
         Long messageId = Long.parseLong(mvcResult.getResponse().getContentAsString());
 
-        Message message = messageRepository.findByIdAndUserId(messageId, user.getId());
+        Message message = messageRepository.findByIdAndUserId(messageId, user.getId()).get();
         assertThat(message.getSenderId()).isEqualTo(-1L);
         assertThat(message.isAnonymous()).isTrue();
 

--- a/src/test/java/com/yapp/betree/controller/MessageAcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageAcceptanceTest.java
@@ -96,7 +96,7 @@ public class MessageAcceptanceTest {
 
         Long messageId = Long.parseLong(mvcResult.getResponse().getContentAsString());
 
-        Message message = messageRepository.findByIdAndUserId(messageId, user.getId());
+        Message message = messageRepository.findByIdAndUserId(messageId, user.getId()).get();
         assertThat(message.getSenderId()).isEqualTo(user.getId());
         assertThat(message.isAnonymous()).isFalse();
 

--- a/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
@@ -19,7 +19,7 @@ import java.util.*;
 
 import static com.yapp.betree.domain.MessageTest.TEST_SAVE_ANONYMOUS_MESSAGE;
 import static com.yapp.betree.domain.MessageTest.TEST_SAVE_MESSAGE;
-import static com.yapp.betree.domain.UserTest.TEST_SAVE_USER;
+import static com.yapp.betree.domain.UserTest.TEST_SAVE_USER_DTO;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -86,8 +86,8 @@ class MessageControllerTest extends ControllerTest {
     @Test
     void getMessageList() throws Exception {
 
-        MessageBoxResponseDto dto1 = MessageBoxResponseDto.of(TEST_SAVE_MESSAGE, TEST_SAVE_USER);
-        MessageBoxResponseDto dto2 = MessageBoxResponseDto.of(TEST_SAVE_ANONYMOUS_MESSAGE, TEST_SAVE_USER);
+        MessageBoxResponseDto dto1 = MessageBoxResponseDto.of(TEST_SAVE_MESSAGE, TEST_SAVE_USER_DTO);
+        MessageBoxResponseDto dto2 = MessageBoxResponseDto.of(TEST_SAVE_ANONYMOUS_MESSAGE, TEST_SAVE_USER_DTO);
         List<MessageBoxResponseDto> messageDto = Arrays.asList(dto1, dto2);
 
         given(messageService.getMessageList(anyLong(), any(), anyLong())).willReturn(MessagePageResponseDto.of(messageDto, false));
@@ -180,7 +180,7 @@ class MessageControllerTest extends ControllerTest {
     @Test
     void getFavoriteMessageList() throws Exception {
 
-        List<MessageBoxResponseDto> messageDto = Collections.singletonList(MessageBoxResponseDto.of(TEST_SAVE_MESSAGE, TEST_SAVE_USER));
+        List<MessageBoxResponseDto> messageDto = Collections.singletonList(MessageBoxResponseDto.of(TEST_SAVE_MESSAGE, TEST_SAVE_USER_DTO));
 
         given(messageService.getFavoriteMessage(anyLong(), any())).willReturn(MessagePageResponseDto.of(messageDto, false));
 

--- a/src/test/java/com/yapp/betree/domain/UserTest.java
+++ b/src/test/java/com/yapp/betree/domain/UserTest.java
@@ -1,5 +1,6 @@
 package com.yapp.betree.domain;
 
+import com.yapp.betree.dto.SendUserDto;
 import com.yapp.betree.util.BetreeUtils;
 import org.junit.jupiter.api.DisplayName;
 
@@ -25,5 +26,10 @@ public class UserTest {
             .userImage("default image uri")
             .lastAccessTime(LocalDateTime.now())
             .url(BetreeUtils.makeUserAccessUrl(1L))
+            .build();
+    public static final SendUserDto TEST_SAVE_USER_DTO = SendUserDto.builder()
+            .id(1L)
+            .nickname("닉네임")
+            .userImage("default image uri")
             .build();
 }

--- a/src/test/java/com/yapp/betree/service/MessageServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/MessageServiceTest.java
@@ -51,16 +51,16 @@ public class MessageServiceTest {
         @DisplayName("메세지함 목록 조회 - folderId 없을 경우 전체 목록 조회")
         void TotalMessageList() {
 
-            SliceImpl<Message> messages = new SliceImpl<>(Arrays.asList(TEST_SAVE_MESSAGE, TEST_SAVE_ANONYMOUS_MESSAGE));
+            SliceImpl<Message> messages = new SliceImpl<>(Collections.singletonList(TEST_SAVE_ANONYMOUS_MESSAGE));
 
             given(messageRepository.findByUserId(TEST_SAVE_USER.getId(), pageable)).willReturn(messages);
             given(messageRepository.findByUserIdAndFolderId(TEST_SAVE_USER.getId(), TEST_SAVE_DEFAULT_TREE.getId(), pageable)).willReturn(messages);
-            given(userRepository.findById(TEST_SAVE_USER.getId())).willReturn(Optional.of(TEST_SAVE_USER));
+
             given(folderRepository.findByUserIdAndFruit(TEST_SAVE_USER.getId(), FruitType.DEFAULT)).willReturn(TEST_SAVE_DEFAULT_TREE);
 
             MessagePageResponseDto messageList = messageService.getMessageList(TEST_SAVE_USER.getId(), pageable, null);
 
-            assertThat(messageList.getResponseDto().size()).isEqualTo(2);
+            assertThat(messageList.getResponseDto().size()).isEqualTo(1);
             assertThat(messageList.getResponseDto().get(0).getId()).isEqualTo(1L);
         }
 
@@ -68,14 +68,13 @@ public class MessageServiceTest {
         @DisplayName("메세지함 목록 조회 - folderId 포함시 나무별 메세지 목록 조회")
         void treeMessageList() {
 
-            SliceImpl<Message> messages = new SliceImpl<>(Arrays.asList(TEST_SAVE_MESSAGE, TEST_SAVE_ANONYMOUS_MESSAGE));
+            SliceImpl<Message> messages = new SliceImpl<>(Collections.singletonList(TEST_SAVE_ANONYMOUS_MESSAGE));
             given(messageRepository.findByUserId(TEST_SAVE_USER.getId(), pageable)).willReturn(messages);
             given(messageRepository.findByUserIdAndFolderId(TEST_SAVE_USER.getId(), TEST_SAVE_DEFAULT_TREE.getId(), pageable)).willReturn(messages);
-            given(userRepository.findById(TEST_SAVE_USER.getId())).willReturn(Optional.of(TEST_SAVE_USER));
 
             MessagePageResponseDto messageList = messageService.getMessageList(TEST_SAVE_USER.getId(), pageable, TEST_SAVE_DEFAULT_TREE.getId());
 
-            assertThat(messageList.getResponseDto().size()).isEqualTo(2);
+            assertThat(messageList.getResponseDto().size()).isEqualTo(1);
             assertThat(messageList.getResponseDto().get(0).getId()).isEqualTo(1L);
         }
     }


### PR DESCRIPTION
## 이슈
- #24 

## 작업 내용
- SenderDto 사용으로 인한 테스트 수정
- Optional<message> Repository.findByIdAndUserId 처리 -> 메세지함 API에서 메세지 관련 예외처리를 위해 Optional 추가함
- MessageBoxResponseDto에 작성 시간 추가 (LocalDateTime)

## 기타 사항
- MessageBoxResponseDto 생성시 LocalDateTime 포맷하여 출력하고 싶었으나 테스트시 NullPointerException가 떠 못 했음
    - `this.createdDate = message.getCreatedDate().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG))`
    -  `--> 2021년 9월 2일 (목) 오후 2시 56분 20초`

## 체크리스트
- [ ] example