### PR TITLE
fix: 나무(폴더) 최대 생성 개수 4개 제한처리

### DIFF
--- a/src/main/java/com/yapp/betree/controller/ForestController.java
+++ b/src/main/java/com/yapp/betree/controller/ForestController.java
@@ -95,7 +95,9 @@ public class ForestController {
     @ApiResponses({
             @ApiResponse(code = 400, message = "[C004]잘못된 ENUM값 입니다.\n" +
                     "[C001]Invalid input value (나무 이름은 빈 값일 수 없습니다, 나무 이름은 20자를 넘을 수 없습니다.)\n" +
-                    "[T002]기본 나무를 생성,변경할 수 없습니다. - fruitType에 Default를 지정할경우"),
+                    "[T002]기본 나무를 생성,변경할 수 없습니다. - fruitType에 Default를 지정할경우\n" +
+                    "[T003]나무는 최대 4개까지 추가 가능합니다. - 현재 추가한 나무가 4개일때 더 생성하려고 할 경우"),
+
             @ApiResponse(code = 404, message = "[U005]회원을 찾을 수 없습니다."),
     })
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/yapp/betree/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/betree/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     // Tree
     TREE_NOT_FOUND(404,"T001", "나무가 존재하지 않습니다."),
     TREE_DEFAULT_ERROR(400,"T002","기본 나무를 생성,변경 할 수 없습니다."),
+    TREE_COUNT_ERROR(400,"T003","나무는 최대 4개까지 추가 가능합니다."),
 
     //Message
     MESSAGE_NOT_FOUND(404,"M001", "메세지가 존재하지 않습니다."),

--- a/src/main/java/com/yapp/betree/repository/FolderRepository.java
+++ b/src/main/java/com/yapp/betree/repository/FolderRepository.java
@@ -23,5 +23,5 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     //next
     Optional<Folder> findTop1ByUserAndIdGreaterThan(User user, Long id);
 
-    Long countByUserId(Long userId);
+    Long countByUserIdAndFruitIsNot(Long userId, FruitType fruitType);
 }

--- a/src/main/java/com/yapp/betree/repository/FolderRepository.java
+++ b/src/main/java/com/yapp/betree/repository/FolderRepository.java
@@ -22,4 +22,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     //next
     Optional<Folder> findTop1ByUserAndIdGreaterThan(User user, Long id);
+
+    Long countByUserId(Long userId);
 }

--- a/src/main/java/com/yapp/betree/service/FolderService.java
+++ b/src/main/java/com/yapp/betree/service/FolderService.java
@@ -2,6 +2,7 @@ package com.yapp.betree.service;
 
 
 import com.yapp.betree.domain.Folder;
+import com.yapp.betree.domain.FruitType;
 import com.yapp.betree.domain.User;
 import com.yapp.betree.dto.SendUserDto;
 import com.yapp.betree.dto.request.TreeRequestDto;
@@ -86,7 +87,7 @@ public class FolderService {
     @Transactional
     public Long createTree(Long userId, TreeRequestDto treeRequestDto) {
 
-        Long count = folderRepository.countByUserId(userId);
+        Long count = folderRepository.countByUserIdAndFruitIsNot(userId, FruitType.DEFAULT);
         if (count == 4L) {
             throw new BetreeException(ErrorCode.TREE_COUNT_ERROR, "나무를 추가할 수 없습니다.");
         }

--- a/src/main/java/com/yapp/betree/service/FolderService.java
+++ b/src/main/java/com/yapp/betree/service/FolderService.java
@@ -12,7 +12,6 @@ import com.yapp.betree.exception.BetreeException;
 import com.yapp.betree.exception.ErrorCode;
 import com.yapp.betree.repository.FolderRepository;
 import com.yapp.betree.repository.MessageRepository;
-import com.yapp.betree.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,6 +85,11 @@ public class FolderService {
      */
     @Transactional
     public Long createTree(Long userId, TreeRequestDto treeRequestDto) {
+
+        Long count = folderRepository.countByUserId(userId);
+        if (count == 4L) {
+            throw new BetreeException(ErrorCode.TREE_COUNT_ERROR, "나무를 추가할 수 없습니다.");
+        }
 
         User user = userService.findById(userId).orElseThrow(() -> new BetreeException(ErrorCode.USER_NOT_FOUND, "userID = " + userId));
 

--- a/src/test/java/com/yapp/betree/service/FolderServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/FolderServiceTest.java
@@ -178,6 +178,23 @@ public class FolderServiceTest {
     }
 
     @Test
+    @DisplayName("유저 나무 추가 - 나무를 4개보다 많이 추가하려고 하면 예외가 발생한다.")
+    void createTreeCountErrorTest() {
+        // given
+        Long userId = 1L;
+        TreeRequestDto apple_tree = TreeRequestDto.builder()
+                .name("apple tree")
+                .fruitType(FruitType.APPLE)
+                .build();
+
+        given(folderRepository.countByUserIdAndFruitIsNot(userId, FruitType.DEFAULT)).willReturn(4L);
+
+        assertThatThrownBy(() -> folderService.createTree(userId, apple_tree))
+                .isInstanceOf(BetreeException.class)
+                .hasMessageContaining("나무는 최대 4개까지 추가 가능합니다.");
+    }
+
+    @Test
     @DisplayName("유저 나무 추가 - 나무 추가")
     void createTreeTest() {
         // given


### PR DESCRIPTION
## 이슈
- #36 
## 작업 내용
- 현재 추가한 나무가 4개일때 더 추가하려고 할 경우 예외처리

## 기타 사항
- 기본 폴더는 메세지함 폴더 목록이나 나무숲에 표시되지 않고 
  햄버거바 - 나에게 온 메세지로 사용되기 때문에 기본 폴더를 제외하고 4개가 추가 가능하다고 이해했습니다 !

## 체크리스트
- [x] 테스트 케이스 추가
- [x] 폴더 개수 셀때 디폴트 폴더는 제외