### PR TITLE
fix: 프론트엔드 건의사항 반영 #47

### DIFF
--- a/src/main/java/com/yapp/betree/controller/ForestController.java
+++ b/src/main/java/com/yapp/betree/controller/ForestController.java
@@ -136,7 +136,7 @@ public class ForestController {
                     "[T001]나무가 존재하지 않습니다."),
     })
     @PutMapping("/api/forest/{treeId}")
-    public ResponseEntity<Void> updateTree(
+    public ResponseEntity<Long> updateTree(
             @ApiIgnore @LoginUser LoginUserDto loginUser,
             @PathVariable Long treeId,
             @Valid @RequestBody TreeRequestDto treeRequestDto) {
@@ -146,6 +146,8 @@ public class ForestController {
         folderService.updateTree(loginUser.getId(), treeId, treeRequestDto);
         log.info("[나무 편집 완료] treeId : {}, {}", treeId, treeRequestDto);
 
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(treeId);
     }
 }

--- a/src/main/java/com/yapp/betree/dto/request/MessageRequestDto.java
+++ b/src/main/java/com/yapp/betree/dto/request/MessageRequestDto.java
@@ -1,6 +1,7 @@
 package com.yapp.betree.dto.request;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +21,7 @@ public class MessageRequestDto {
 
     @NotNull(message = "받는사람 id를 입력해주세요.")
     @Positive(message = "올바른 id를 입력해주세요.")
+    @ApiModelProperty(value = "칭찬 메시지를 보낼 나무숲 주인 유저 아이디(받는사람)")
     private Long receiverId;
 
     @NotBlank(message = "메시지를 입력해주세요.")
@@ -27,6 +29,7 @@ public class MessageRequestDto {
     private String content;
 
     @Positive(message = "올바른 id를 입력해주세요.")
+    @ApiModelProperty(value = "칭찬 메시지를 보낼 지정 폴더, 자신에게 보낼때만 id를 명시하고 다른사람에게 보낼 때는 null로 입력")
     private Long folderId;
 
     private boolean anonymous;

--- a/src/main/java/com/yapp/betree/dto/response/TreeResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/TreeResponseDto.java
@@ -1,6 +1,7 @@
 package com.yapp.betree.dto.response;
 
 import com.yapp.betree.domain.Folder;
+import com.yapp.betree.domain.FruitType;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,17 +15,20 @@ public class TreeResponseDto {
 
     private Long id;
     private String name;
+    private FruitType fruit;
 
     @Builder
-    public TreeResponseDto(Long id, String name) {
+    public TreeResponseDto(Long id, String name, FruitType fruit) {
         this.id = id;
         this.name = name;
+        this.fruit = fruit;
     }
 
     public static TreeResponseDto of(Folder folder) {
         return TreeResponseDto.builder()
                 .id(folder.getId())
                 .name(folder.getName())
+                .fruit(folder.getFruit())
                 .build();
     }
 
@@ -40,6 +44,9 @@ public class TreeResponseDto {
             return false;
         }
         if (!this.name.equals(objDto.getName())) {
+            return false;
+        }
+        if (this.fruit != objDto.getFruit()) {
             return false;
         }
         return true;

--- a/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
@@ -193,7 +193,8 @@ public class ForestControllerTest extends ControllerTest {
                 .content(objectMapper.writeValueAsString(input))
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andDo(print())
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(18));
     }
 
     @DisplayName("나무 편집 - 변경하려는 나무가 DEFAULT타입인 경우 예외가 발생한다.")

--- a/src/test/java/com/yapp/betree/domain/FolderTest.java
+++ b/src/test/java/com/yapp/betree/domain/FolderTest.java
@@ -58,6 +58,7 @@ public class FolderTest {
         TreeResponseDto build = TreeResponseDto.builder()
                 .id(TEST_SAVE_APPLE_TREE.getId())
                 .name(TEST_SAVE_APPLE_TREE.getName())
+                .fruit(TEST_SAVE_APPLE_TREE.getFruit())
                 .build();
         assertThat(of).isEqualTo(build);
         assertThat(of.hashCode()).isEqualTo(build.hashCode());

--- a/src/test/java/com/yapp/betree/repository/folderRepositoryTest.java
+++ b/src/test/java/com/yapp/betree/repository/folderRepositoryTest.java
@@ -24,9 +24,9 @@ public class folderRepositoryTest {
     @DisplayName("countByUserIdAndFruitIsNot 테스트")
     void countByUserIdAndFruitIsNot() {
         // given
+        TEST_USER.addFolder(TEST_APPLE_TREE);
+        TEST_USER.addFolder(TEST_DEFAULT_TREE);
         userRepository.save(TEST_USER);
-        folderRepository.save(TEST_APPLE_TREE);
-        folderRepository.save(TEST_DEFAULT_TREE);
 
         //when
         Long count = folderRepository.countByUserIdAndFruitIsNot(TEST_SAVE_USER.getId(), FruitType.DEFAULT);


### PR DESCRIPTION
## 이슈
- #47 

## 작업 내용
- 유저나무숲 조회 응답에 열매 타입 추가
- 나무 편집 API 응답으로 편집된 나무 id 반환
- 물주기 요청 DTO 스웨거 문서 설명 추가

## 기타 사항
- 유저 나무 목록 API는 이야기가 좀 더 필요해보입니다 .. -> 유저 나무숲 조회와 함께 쓰는걸로 결론났습니다!

## 체크리스트
- [x] 테스트코드 성공 확인