### PR TITLE
[fix] 발신자, 수신자에 따른 개별 삭제 처리

### DIFF
--- a/src/main/java/com/yapp/betree/domain/Message.java
+++ b/src/main/java/com/yapp/betree/domain/Message.java
@@ -28,6 +28,8 @@ public class Message extends BaseTimeEntity {
     private boolean alreadyRead;
     private boolean favorite;
     private boolean opening;
+    private boolean delBySender;
+    private boolean delByReceiver;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -37,8 +39,9 @@ public class Message extends BaseTimeEntity {
     @JoinColumn(name = "folder_id")
     private Folder folder;
 
+
     @Builder
-    public Message(Long id, String content, Long senderId, boolean anonymous, boolean alreadyRead, boolean favorite, boolean opening, User user, Folder folder) {
+    public Message(Long id, String content, Long senderId, boolean anonymous, boolean alreadyRead, boolean favorite, boolean opening, boolean delBySender, boolean delByReceiver, User user, Folder folder) {
         this.id = id;
         this.content = content;
         this.senderId = senderId;
@@ -46,6 +49,8 @@ public class Message extends BaseTimeEntity {
         this.alreadyRead = alreadyRead;
         this.favorite = favorite;
         this.opening = opening;
+        this.delBySender = delBySender;
+        this.delByReceiver = delByReceiver;
         this.user = user;
         this.folder = folder;
     }
@@ -83,6 +88,17 @@ public class Message extends BaseTimeEntity {
      */
     public void updateFavorite() {
         this.favorite = !this.favorite;
+    }
+
+    /**
+     * 메세지 삭제 여부 상태 변경 메서드
+     */
+    public void deleteBySender() {
+        this.delBySender = true;
+    }
+
+    public void deleteByReceiver() {
+        this.delByReceiver = true;
     }
 
 }

--- a/src/main/java/com/yapp/betree/domain/Message.java
+++ b/src/main/java/com/yapp/betree/domain/Message.java
@@ -93,12 +93,13 @@ public class Message extends BaseTimeEntity {
     /**
      * 메세지 삭제 여부 상태 변경 메서드
      */
-    public void deleteBySender() {
-        this.delBySender = true;
+    public void updateDeleteStatus(Long userId, Message message) {
+        if (userId.equals(message.getSenderId())) {
+            this.delBySender = true;
+        }
+        if (userId.equals(message.getUser().getId())) {
+            this.delByReceiver = true;
+            updateAlreadyRead(); // 안 읽고 삭제할 때
+        }
     }
-
-    public void deleteByReceiver() {
-        this.delByReceiver = true;
-    }
-
 }

--- a/src/main/java/com/yapp/betree/domain/Message.java
+++ b/src/main/java/com/yapp/betree/domain/Message.java
@@ -93,11 +93,11 @@ public class Message extends BaseTimeEntity {
     /**
      * 메세지 삭제 여부 상태 변경 메서드
      */
-    public void updateDeleteStatus(Long userId, Message message) {
-        if (userId.equals(message.getSenderId())) {
+    public void updateDeleteStatus(Long userId) {
+        if (userId.equals(this.senderId)) {
             this.delBySender = true;
         }
-        if (userId.equals(message.getUser().getId())) {
+        if (userId.equals(this.user.getId())) {
             this.delByReceiver = true;
             updateAlreadyRead(); // 안 읽고 삭제할 때
         }

--- a/src/main/java/com/yapp/betree/repository/MessageRepository.java
+++ b/src/main/java/com/yapp/betree/repository/MessageRepository.java
@@ -11,21 +11,19 @@ import java.util.Optional;
 
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
-    List<Message> findByUserIdAndOpening(Long userId, boolean opening);
+    List<Message> findByUserIdAndOpeningAndDelByReceiver(Long userId, boolean opening, boolean delByReceiver);
 
-    Slice<Message> findByUserId(Long userId, Pageable pageable);
+    Slice<Message> findByUserIdAndFolderIdAndDelByReceiver(Long userId, Long treeId, boolean delByReceiver, Pageable pageable);
 
-    Slice<Message> findByUserIdAndFolderId(Long userId, Long treeId, Pageable pageable);
-
-    List<Message> findTop8ByFolderIdAndOpening(Long treeId, boolean opening);
+    List<Message> findTop8ByFolderIdAndOpeningAndDelByReceiver(Long treeId, boolean opening, boolean delByReceiver);
 
     List<Message> findByUserIdAndAlreadyRead(Long userId, boolean alreadyRead);
 
     // 알림나무 즐겨찾기 메시지 조회용
-    List<Message> findAllByUserIdAndFavorite(Long userId, boolean favorite);
+    List<Message> findAllByUserIdAndFavoriteAndDelByReceiver(Long userId, boolean favorite, boolean delByReceiver);
 
-    Optional<Message> findByIdAndUserId(Long id, Long userId);
+    Optional<Message> findByIdAndUserIdAndDelByReceiver(Long id, Long userId, boolean delByReceiver);
 
     // 메시지함 즐겨찾기한 메시지 조회용
-    Slice<Message> findByUserIdAndFavorite(Long userId, boolean favorite, Pageable pageable);
+    Slice<Message> findByUserIdAndFavoriteAndDelByReceiver(Long userId, boolean favorite, boolean delByReceiver, Pageable pageable);
 }

--- a/src/main/java/com/yapp/betree/repository/MessageRepository.java
+++ b/src/main/java/com/yapp/betree/repository/MessageRepository.java
@@ -17,7 +17,7 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
 
     List<Message> findTop8ByFolderIdAndOpeningAndDelByReceiver(Long treeId, boolean opening, boolean delByReceiver);
 
-    List<Message> findByUserIdAndAlreadyRead(Long userId, boolean alreadyRead);
+    List<Message> findByUserIdAndAlreadyReadAndDelByReceiver(Long userId, boolean alreadyRead, boolean delByReceiver);
 
     // 알림나무 즐겨찾기 메시지 조회용
     List<Message> findAllByUserIdAndFavoriteAndDelByReceiver(Long userId, boolean favorite, boolean delByReceiver);

--- a/src/main/java/com/yapp/betree/service/FolderService.java
+++ b/src/main/java/com/yapp/betree/service/FolderService.java
@@ -68,7 +68,7 @@ public class FolderService {
                 .orElse(0L);
 
         // opening == true 인 메세지 8개 가져오기
-        List<MessageResponseDto> messageResponseDtos = messageRepository.findTop8ByFolderIdAndOpening(treeId, true)
+        List<MessageResponseDto> messageResponseDtos = messageRepository.findTop8ByFolderIdAndOpeningAndDelByReceiver(treeId, true, false)
                 .stream()
                 .map(m -> {
                     SendUserDto sender = userService.findBySenderId(m.getSenderId());

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -91,17 +91,14 @@ public class MessageService {
      */
     public MessagePageResponseDto getMessageList(Long userId, Pageable pageable, Long treeId) {
 
-        //다음 페이지 존재 여부
-        boolean hasNext = messageRepository.findByUserId(userId, pageable).hasNext();
-
         Slice<Message> messages;
         if (treeId == null) {
             //기본 폴더 목록 조회
             Long defaultTreeId = folderRepository.findByUserIdAndFruit(userId, FruitType.DEFAULT).getId();
-            messages = messageRepository.findByUserIdAndFolderId(userId, defaultTreeId, pageable);
+            messages = messageRepository.findByUserIdAndFolderIdAndDelByReceiver(userId, defaultTreeId, false, pageable);
         } else {
             //해당 폴더 메세지 목록 조회
-            messages = messageRepository.findByUserIdAndFolderId(userId, treeId, pageable);
+            messages = messageRepository.findByUserIdAndFolderIdAndDelByReceiver(userId, treeId, false, pageable);
         }
 
         List<MessageBoxResponseDto> responseDtos = new ArrayList<>();
@@ -114,7 +111,7 @@ public class MessageService {
                 responseDtos.add(MessageBoxResponseDto.of(message, sender));
             }
         }
-        return new MessagePageResponseDto(responseDtos, hasNext);
+        return new MessagePageResponseDto(responseDtos, messages.hasNext());
     }
 
     /**
@@ -130,7 +127,7 @@ public class MessageService {
             throw new BetreeException(ErrorCode.INVALID_INPUT_VALUE, "열매로 맺을 수 있는 메세지 개수는 최대 8개입니다.");
         }
         //이미 선택된 메세지 가져와서 false로 변경
-        messageRepository.findByUserIdAndOpening(userId, true).forEach(Message::updateOpening);
+        messageRepository.findByUserIdAndOpeningAndDelByReceiver(userId, true, false).forEach(Message::updateOpening);
 
         // 지금 선택된 메세지만 true로 변경
         for (Long id : messageIds) {
@@ -147,9 +144,15 @@ public class MessageService {
     @Transactional
     public void deleteMessages(Long userId, List<Long> messageIds) {
 
+        // 메세지의 발신자, 수신자 확인 후 알맞는 삭제 여부 필드 변경
         messageIds.forEach(messageId -> {
-            Message message = messageRepository.findByIdAndUserId(messageId, userId).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId = " + messageId + "userId = " + userId));
-            messageRepository.delete(message);
+            Message message = messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, userId, false).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId = " + messageId + "userId = " + userId));
+            message.updateDeleteStatus(userId, message);
+
+            // 수신자, 발신자 모두 삭제 true 이면 db 삭제
+            if (message.isDelByReceiver() && message.isDelBySender()) {
+                messageRepository.delete(message);
+            }
         });
     }
 
@@ -165,7 +168,7 @@ public class MessageService {
 
         Folder folder = folderRepository.findById(treeId).orElseThrow(() -> new BetreeException(TREE_NOT_FOUND, "treeId = " + treeId));
 
-        messageIds.forEach(messageId -> messageRepository.findByIdAndUserId(messageId, userId).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId + "userId = " + userId))
+        messageIds.forEach(messageId -> messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, userId, false).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId + "userId = " + userId))
                 .updateFolder(folder));
     }
 
@@ -178,7 +181,7 @@ public class MessageService {
     @Transactional
     public void updateFavoriteMessage(Long userId, Long messageId) {
 
-        messageRepository.findByIdAndUserId(messageId, userId).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId))
+        messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, userId, false).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId))
                 .updateFavorite();
     }
 
@@ -193,7 +196,7 @@ public class MessageService {
     public MessagePageResponseDto getFavoriteMessage(Long userId, Pageable pageable) {
 
         //다음 페이지 존재 여부
-        Slice<Message> messages = messageRepository.findByUserIdAndFavorite(userId, true, pageable);
+        Slice<Message> messages = messageRepository.findByUserIdAndFavoriteAndDelByReceiver(userId, true, false, pageable);
 
         List<MessageBoxResponseDto> responseMessages = messages
                 .stream()
@@ -215,7 +218,7 @@ public class MessageService {
     @Transactional
     public void updateReadMessage(Long userId, Long messageId) {
 
-        messageRepository.findByIdAndUserId(messageId, userId).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId))
+        messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, userId, false).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId))
                 .updateAlreadyRead();
         noticeTreeService.updateNoticeTree(userId, messageId);
     }

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -147,7 +147,7 @@ public class MessageService {
         // 메세지의 발신자, 수신자 확인 후 알맞는 삭제 여부 필드 변경
         messageIds.forEach(messageId -> {
             Message message = messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, userId, false).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId = " + messageId + "userId = " + userId));
-            message.updateDeleteStatus(userId, message);
+            message.updateDeleteStatus(userId);
 
             // 수신자, 발신자 모두 삭제 true 이면 db 삭제
             if (message.isDelByReceiver() && message.isDelBySender()) {

--- a/src/main/java/com/yapp/betree/service/NoticeTreeService.java
+++ b/src/main/java/com/yapp/betree/service/NoticeTreeService.java
@@ -96,7 +96,7 @@ public class NoticeTreeService {
         }
 
         // 즐겨찾기 메시지
-        List<Message> favoriteMessages = messageRepository.findAllByUserIdAndFavorite(userId, true);
+        List<Message> favoriteMessages = messageRepository.findAllByUserIdAndFavoriteAndDelByReceiver(userId, true, false);
         for (Message m : favoriteMessages) {
             if (noticeTreeMessages.size() >= 8) {
                 break; // 8개까지만 담음

--- a/src/main/java/com/yapp/betree/service/NoticeTreeService.java
+++ b/src/main/java/com/yapp/betree/service/NoticeTreeService.java
@@ -60,7 +60,7 @@ public class NoticeTreeService {
             SendUserDto sender = userService.findBySenderId(message.getSenderId());
             messages.add(MessageResponseDto.of(message, sender));
         }
-        return new NoticeResponseDto(messageRepository.findByUserIdAndAlreadyRead(userId, false).size(), messages);
+        return new NoticeResponseDto(messageRepository.findByUserIdAndAlreadyReadAndDelByReceiver(userId, false, false).size(), messages);
     }
 
     @Transactional
@@ -86,7 +86,7 @@ public class NoticeTreeService {
      */
     private void noticeTree(Long userId) {
         // 안읽은 메시지
-        List<Message> unreadMessages = messageRepository.findByUserIdAndAlreadyRead(userId, false);
+        List<Message> unreadMessages = messageRepository.findByUserIdAndAlreadyReadAndDelByReceiver(userId, false, false);
 
         // 안읽은 메시지 먼저 8개 리스트에 넣음
         Set<MessageResponseDto> noticeTreeMessages = new HashSet<>();

--- a/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
@@ -109,7 +109,7 @@ public class AcceptanceTest {
 
     @Test
     @DisplayName("안읽은 메시지 조회 테스트")
-    void findByUserIdAndAlreadyReadTest() {
+    void findByUserIdAndAlreadyReadAndDelByReceiverTest() {
 
         TEST_USER.addFolder(FolderTest.TEST_APPLE_TREE);
 
@@ -163,7 +163,7 @@ public class AcceptanceTest {
         messageService.updateFavoriteMessage(user.getId(), message3.getId());
 
         // 안읽은 메시지
-        List<Message> unreadMessages = messageRepository.findByUserIdAndAlreadyRead(user.getId(), false);
+        List<Message> unreadMessages = messageRepository.findByUserIdAndAlreadyReadAndDelByReceiver(user.getId(), false, false);
         assertThat(unreadMessages).hasSize(2);
 
         // 안읽은 메시지 먼저 8개 리스트에 넣음

--- a/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
@@ -174,7 +174,7 @@ public class AcceptanceTest {
         }
 
         // 즐겨찾기 메시지
-        List<Message> favoriteMessages = messageRepository.findAllByUserIdAndFavorite(user.getId(), true);
+        List<Message> favoriteMessages = messageRepository.findAllByUserIdAndFavoriteAndDelByReceiver(user.getId(), true, false);
         for (Message m : favoriteMessages) {
             if (noticeTreeMessages.size() >= 8) break; // 8개까지만 담음
             SendUserDto sender = userService.findBySenderId(m.getSenderId());
@@ -226,7 +226,7 @@ public class AcceptanceTest {
 
         Long messageId = Long.parseLong(mvcResult.getResponse().getContentAsString());
 
-        Message message = messageRepository.findByIdAndUserId(messageId, user.getId()).get();
+        Message message = messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, user.getId(), false).get();
         assertThat(message.getSenderId()).isEqualTo(-1L);
         assertThat(message.isAnonymous()).isTrue();
 

--- a/src/test/java/com/yapp/betree/controller/MessageAcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageAcceptanceTest.java
@@ -105,10 +105,7 @@ public class MessageAcceptanceTest {
     @Test
     @DisplayName("메세지 삭제 필드 변경 확인 테스트")
     public void deleteMessage() throws Exception {
-        Folder folder = FolderTest.TEST_DEFAULT_TREE;
-        User user = UserTest.TEST_USER;
-        user.addFolder(folder);
-        userRepository.save(user);
+        User user = userRepository.save(UserTest.TEST_USER);
 
         Message message = Message.builder()
                 .content("삭제 예정")

--- a/src/test/java/com/yapp/betree/controller/MessageAcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageAcceptanceTest.java
@@ -27,14 +27,11 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -96,13 +93,47 @@ public class MessageAcceptanceTest {
 
         Long messageId = Long.parseLong(mvcResult.getResponse().getContentAsString());
 
-        Message message = messageRepository.findByIdAndUserId(messageId, user.getId()).get();
+        Message message = messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, user.getId(), false).get();
         assertThat(message.getSenderId()).isEqualTo(user.getId());
         assertThat(message.isAnonymous()).isFalse();
 
         SendUserDto sender = userService.findBySenderId(message.getSenderId());
         assertThat(sender.getId()).isEqualTo(user.getId());
         assertThat(sender.getUserImage()).isEqualTo(UserTest.TEST_USER.getUserImage());
+    }
+
+    @Test
+    @DisplayName("메세지 삭제 필드 변경 확인 테스트")
+    public void deleteMessage() throws Exception {
+        Folder folder = FolderTest.TEST_DEFAULT_TREE;
+        User user = UserTest.TEST_USER;
+        user.addFolder(folder);
+        userRepository.save(user);
+
+        Message message = Message.builder()
+                .content("삭제 예정")
+                .senderId(UserTest.TEST_SAVE_USER.getId())
+                .user(user)
+                .build();
+
+        messageRepository.save(message);
+
+        String token = JwtTokenTest.JWT_TOKEN_TEST;
+        given(jwtTokenProvider.parseToken(token)).willReturn(claims(user.getId()));
+
+        //받은 메세지 삭제
+        List<Long> messageIds = new ArrayList<>(Collections.singletonList(message.getId()));
+
+        mockMvc.perform(delete("/api/messages")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(messageIds)))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+
+        List<Message> all = messageRepository.findAll();
+        assertThat(all.get(all.size() - 1).isDelBySender()).isFalse();
+        assertThat(all.get(all.size() - 1).isDelByReceiver()).isTrue();
     }
 
     private Claims claims(Long userId) {

--- a/src/test/java/com/yapp/betree/domain/MessageTest.java
+++ b/src/test/java/com/yapp/betree/domain/MessageTest.java
@@ -39,19 +39,6 @@ public class MessageTest {
             .opening(false)
             .build();
 
-    public static Message TEST_SAVE_DELETE_MESSAGE = Message.builder()
-            .id(1L)
-            .content("메시지내용")
-            .senderId(TEST_SAVE_USER.getId())
-            .user(TEST_SAVE_USER) // 받은사람
-            .folder(TEST_SAVE_DEFAULT_TREE)
-            .anonymous(true)
-            .alreadyRead(false)
-            .favorite(true)
-            .opening(false)
-            .delByReceiver(true)
-            .build();
-
     @DisplayName("MessageResponseDto Set으로 중복 처리 되는지 테스트")
     @Test
     void messageResponseDtoSetTest() {

--- a/src/test/java/com/yapp/betree/domain/MessageTest.java
+++ b/src/test/java/com/yapp/betree/domain/MessageTest.java
@@ -39,6 +39,19 @@ public class MessageTest {
             .opening(false)
             .build();
 
+    public static Message TEST_SAVE_DELETE_MESSAGE = Message.builder()
+            .id(1L)
+            .content("메시지내용")
+            .senderId(TEST_SAVE_USER.getId())
+            .user(TEST_SAVE_USER) // 받은사람
+            .folder(TEST_SAVE_DEFAULT_TREE)
+            .anonymous(true)
+            .alreadyRead(false)
+            .favorite(true)
+            .opening(false)
+            .delByReceiver(true)
+            .build();
+
     @DisplayName("MessageResponseDto Set으로 중복 처리 되는지 테스트")
     @Test
     void messageResponseDtoSetTest() {

--- a/src/test/java/com/yapp/betree/repository/MessageRepositoryTest.java
+++ b/src/test/java/com/yapp/betree/repository/MessageRepositoryTest.java
@@ -57,7 +57,7 @@ public class MessageRepositoryTest {
                 .build();
         messageRepository.save(message1);
 
-        List<Message> messages = messageRepository.findAllByUserIdAndFavorite(user.getId(), true);
+        List<Message> messages = messageRepository.findAllByUserIdAndFavoriteAndDelByReceiver(user.getId(), true, false);
         assertThat(messages).hasSize(1);
     }
 }

--- a/src/test/java/com/yapp/betree/repository/folderRepositoryTest.java
+++ b/src/test/java/com/yapp/betree/repository/folderRepositoryTest.java
@@ -1,13 +1,13 @@
 package com.yapp.betree.repository;
 
 import com.yapp.betree.domain.FruitType;
+import com.yapp.betree.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import static com.yapp.betree.domain.FolderTest.*;
-import static com.yapp.betree.domain.UserTest.TEST_SAVE_USER;
 import static com.yapp.betree.domain.UserTest.TEST_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,10 +26,10 @@ public class folderRepositoryTest {
         // given
         TEST_USER.addFolder(TEST_APPLE_TREE);
         TEST_USER.addFolder(TEST_DEFAULT_TREE);
-        userRepository.save(TEST_USER);
+        User user = userRepository.save(TEST_USER);
 
         //when
-        Long count = folderRepository.countByUserIdAndFruitIsNot(TEST_SAVE_USER.getId(), FruitType.DEFAULT);
+        Long count = folderRepository.countByUserIdAndFruitIsNot(user.getId(), FruitType.DEFAULT);
 
         // then
         assertThat(count).isEqualTo(1); //기본폴더 제외 유저 폴더 개수

--- a/src/test/java/com/yapp/betree/service/FolderServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/FolderServiceTest.java
@@ -91,7 +91,7 @@ public class FolderServiceTest {
         List<Message> messages = Lists.newArrayList(TEST_SAVE_ANONYMOUS_MESSAGE);
 
         given(folderRepository.findById(TREE_ID)).willReturn(Optional.of(TEST_SAVE_DEFAULT_TREE));
-        given(messageRepository.findTop8ByFolderIdAndOpening(TREE_ID, true)).willReturn(messages);
+        given(messageRepository.findTop8ByFolderIdAndOpeningAndDelByReceiver(TREE_ID, true, false)).willReturn(messages);
         given(userService.findBySenderId(USER_ID)).willReturn(SendUserDto.ofNoLogin());
 
         // when
@@ -114,7 +114,7 @@ public class FolderServiceTest {
         List<Message> messages = Lists.newArrayList(TEST_SAVE_MESSAGE);
 
         given(folderRepository.findById(TREE_ID)).willReturn(Optional.of(TEST_SAVE_DEFAULT_TREE));
-        given(messageRepository.findTop8ByFolderIdAndOpening(TREE_ID, true)).willReturn(messages);
+        given(messageRepository.findTop8ByFolderIdAndOpeningAndDelByReceiver(TREE_ID, true, false)).willReturn(messages);
         given(userService.findBySenderId(USER_ID)).willThrow(new BetreeException(ErrorCode.USER_NOT_FOUND, "senderId = " + USER_ID));
 
         // then
@@ -130,7 +130,7 @@ public class FolderServiceTest {
         List<Message> messages = Lists.newArrayList(TEST_SAVE_ANONYMOUS_MESSAGE);
 
         given(folderRepository.findById(TREE_ID)).willReturn(Optional.of(TEST_SAVE_DEFAULT_TREE));
-        given(messageRepository.findTop8ByFolderIdAndOpening(TREE_ID, true)).willReturn(messages);
+        given(messageRepository.findTop8ByFolderIdAndOpeningAndDelByReceiver(TREE_ID, true, false)).willReturn(messages);
         given(userService.findBySenderId(USER_ID)).willReturn(SendUserDto.of(TEST_SAVE_USER));
 
         // when
@@ -154,7 +154,7 @@ public class FolderServiceTest {
         given(folderRepository.findById(TREE_ID)).willReturn(Optional.of(TEST_SAVE_DEFAULT_TREE));
         given(folderRepository.findTop1ByUserAndIdGreaterThan(TEST_SAVE_USER, TREE_ID)).willReturn(Optional.empty());
         given(folderRepository.findTop1ByUserAndIdGreaterThan(TEST_SAVE_USER, TREE_ID)).willReturn(Optional.empty());
-        given(messageRepository.findTop8ByFolderIdAndOpening(TREE_ID, true)).willReturn(messages);
+        given(messageRepository.findTop8ByFolderIdAndOpeningAndDelByReceiver(TREE_ID, true, false)).willReturn(messages);
         given(userService.findBySenderId(USER_ID)).willReturn(SendUserDto.of(TEST_SAVE_USER));
 
         // when

--- a/src/test/java/com/yapp/betree/service/MessageServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/MessageServiceTest.java
@@ -48,14 +48,11 @@ public class MessageServiceTest {
     class getMessageList {
 
         @Test
-        @DisplayName("메세지함 목록 조회 - folderId 없을 경우 전체 목록 조회")
+        @DisplayName("메세지함 목록 조회 - folderId 없을 경우 기본 폴더 목록 조회")
         void TotalMessageList() {
 
             SliceImpl<Message> messages = new SliceImpl<>(Collections.singletonList(TEST_SAVE_ANONYMOUS_MESSAGE));
-
-            given(messageRepository.findByUserId(TEST_SAVE_USER.getId(), pageable)).willReturn(messages);
-            given(messageRepository.findByUserIdAndFolderId(TEST_SAVE_USER.getId(), TEST_SAVE_DEFAULT_TREE.getId(), pageable)).willReturn(messages);
-
+            given(messageRepository.findByUserIdAndFolderIdAndDelByReceiver(TEST_SAVE_USER.getId(), TEST_SAVE_DEFAULT_TREE.getId(), false, pageable)).willReturn(messages);
             given(folderRepository.findByUserIdAndFruit(TEST_SAVE_USER.getId(), FruitType.DEFAULT)).willReturn(TEST_SAVE_DEFAULT_TREE);
 
             MessagePageResponseDto messageList = messageService.getMessageList(TEST_SAVE_USER.getId(), pageable, null);
@@ -69,8 +66,7 @@ public class MessageServiceTest {
         void treeMessageList() {
 
             SliceImpl<Message> messages = new SliceImpl<>(Collections.singletonList(TEST_SAVE_ANONYMOUS_MESSAGE));
-            given(messageRepository.findByUserId(TEST_SAVE_USER.getId(), pageable)).willReturn(messages);
-            given(messageRepository.findByUserIdAndFolderId(TEST_SAVE_USER.getId(), TEST_SAVE_DEFAULT_TREE.getId(), pageable)).willReturn(messages);
+            given(messageRepository.findByUserIdAndFolderIdAndDelByReceiver(TEST_SAVE_USER.getId(), TEST_SAVE_DEFAULT_TREE.getId(), false, pageable)).willReturn(messages);
 
             MessagePageResponseDto messageList = messageService.getMessageList(TEST_SAVE_USER.getId(), pageable, TEST_SAVE_DEFAULT_TREE.getId());
 
@@ -107,7 +103,7 @@ public class MessageServiceTest {
     @DisplayName("메세지 삭제 - 존재하지 않는 messageId 입력시 예외 발생")
     void messageNotFound() {
 
-        given(messageRepository.findByIdAndUserId(1L, TEST_SAVE_USER.getId())).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
+        given(messageRepository.findByIdAndUserIdAndDelByReceiver(1L, TEST_SAVE_USER.getId(), false)).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
 
         List<Long> messageIds = Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
 
@@ -132,7 +128,7 @@ public class MessageServiceTest {
     @DisplayName("메세지 즐겨찾기 설정 - 존재하지 않는 messageId 입력시 예외 발생")
     void favoriteMessageNotFound() {
 
-        given(messageRepository.findByIdAndUserId(10L, TEST_SAVE_USER.getId())).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
+        given(messageRepository.findByIdAndUserIdAndDelByReceiver(10L, TEST_SAVE_USER.getId(), false)).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
 
         assertThatThrownBy(() -> messageService.updateFavoriteMessage(TEST_SAVE_USER.getId(), 10L))
                 .isInstanceOf(BetreeException.class)
@@ -144,7 +140,7 @@ public class MessageServiceTest {
     void getFavoriteMessages() {
 
         SliceImpl<Message> messages = new SliceImpl<>(Collections.singletonList(TEST_SAVE_MESSAGE));
-        given(messageRepository.findByUserIdAndFavorite(TEST_SAVE_USER.getId(), true, pageable)).willReturn(messages);
+        given(messageRepository.findByUserIdAndFavoriteAndDelByReceiver(TEST_SAVE_USER.getId(), true, false, pageable)).willReturn(messages);
         given(userRepository.findById(TEST_SAVE_MESSAGE.getSenderId())).willReturn(Optional.of(TEST_SAVE_USER));
 
         MessagePageResponseDto favoriteMessage = messageService.getFavoriteMessage(TEST_SAVE_USER.getId(), pageable);
@@ -158,7 +154,7 @@ public class MessageServiceTest {
     @DisplayName("메세지 읽음 설정 - 존재하지 않는 messageId 입력시 예외 발생")
     void readMessageNotFound() {
 
-        given(messageRepository.findByIdAndUserId(10L, TEST_SAVE_USER.getId())).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
+        given(messageRepository.findByIdAndUserIdAndDelByReceiver(10L, TEST_SAVE_USER.getId(), false)).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
 
         assertThatThrownBy(() -> messageService.updateReadMessage(TEST_SAVE_USER.getId(), 10L))
                 .isInstanceOf(BetreeException.class)


### PR DESCRIPTION
## 이슈
- #44 

## 작업 내용
- message 엔티티에 삭제 필드 추가 (delBySender, delByReceiver)
- delBySender, delByReceiver 모두 true이면 db에서 삭제 (자기 자신에게 쓴 메세지는 바로 물리삭제)
- 메세지 목록 조회시 삭제 여부 확인 추가
- 안 읽고 삭제할때도 읽음 여부 true 설정
- 테스트 케이스 ( 삭제시 필드 상태 변환 확인 )

## 기타 사항
- 알림나무에서 안 읽은 메세지 조회하는 jpa에는 삭제체크 추가 안했는데 해야지 맞는 걸까요,,
    - (어차피 삭제하면 읽음 처리되서 안 했습니다만 그렇게 되면 다른 것도 이런 식이 되서 그냥 다 추가하는 게 맞는걸까요..)
    - ( 뭔가 jpa 마다 다 추가해버리니 무식해보여서 다른게 없을까 했는데 발신자 수신자마다 또 조건 필드가 다 다르다보니 다른 건 생각 못 해봤어요 ㅠㅠ )
- 삭제필드 체크하는 예외처리도 있는게 나을까요? errCode 새로 만들면 로직마다 조건달아서 확인해야할까 싶어서 안 했습니다.
- 삭제는 리턴 값이 없어 mock 테스트가 어렵더라구요 그래서 MessageAcceptanceTest에만 추가 했는데 더 추가해야 될 것 같으면 말씀해주세요

## 체크리스트
- [ ] example