### PR TITLE
[feat] 메세지 상세 조회 api 및 테스트 추가

### DIFF
--- a/src/main/java/com/yapp/betree/controller/MessageController.java
+++ b/src/main/java/com/yapp/betree/controller/MessageController.java
@@ -3,6 +3,7 @@ package com.yapp.betree.controller;
 import com.yapp.betree.annotation.LoginUser;
 import com.yapp.betree.dto.LoginUserDto;
 import com.yapp.betree.dto.request.MessageRequestDto;
+import com.yapp.betree.dto.response.MessageDetailResponseDto;
 import com.yapp.betree.dto.response.MessagePageResponseDto;
 import com.yapp.betree.service.MessageService;
 import io.swagger.annotations.Api;
@@ -214,4 +215,24 @@ public class MessageController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    /**
+     * 메세지 상세 조회
+     *
+     * @param loginUser
+     * @param messageId
+     * @return
+     */
+    @ApiOperation(value = "메세지 상세 조회", notes = "메세지 상세 조회")
+    @ApiResponses({
+            @ApiResponse(code = 404, message = "[M001]메세지가 존재하지 않습니다.\n" +
+                    "[U005]회원을 찾을 수 없습니다. (보낸 유저가 존재하지 않음)")
+    })
+    @GetMapping("/api/messages/{messageId}")
+    public ResponseEntity<MessageDetailResponseDto> getMessageDetail(@ApiIgnore @LoginUser LoginUserDto loginUser,
+                                                                     @PathVariable Long messageId) {
+
+        log.info("[메세지 상세 조회] userId: {}, messageId: {}", loginUser.getId(), messageId);
+
+        return ResponseEntity.ok(messageService.getMessageDetail(loginUser.getId(), messageId));
+    }
 }

--- a/src/main/java/com/yapp/betree/dto/response/MessageDetailResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessageDetailResponseDto.java
@@ -1,0 +1,28 @@
+package com.yapp.betree.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessageDetailResponseDto {
+
+    private MessageBoxResponseDto responseDto;
+    private Long prevId;
+    private Long nextId;
+
+
+    @Builder
+    public MessageDetailResponseDto(MessageBoxResponseDto responseDto, Long prevId, Long nextId) {
+        this.responseDto = responseDto;
+        this.prevId = prevId;
+        this.nextId = nextId;
+    }
+
+    public static MessageDetailResponseDto of(MessageBoxResponseDto responseDto, Long prevId, Long nextId) {
+        return MessageDetailResponseDto.builder()
+                .responseDto(responseDto)
+                .prevId(prevId)
+                .nextId(nextId)
+                .build();
+    }
+}

--- a/src/main/java/com/yapp/betree/repository/MessageRepository.java
+++ b/src/main/java/com/yapp/betree/repository/MessageRepository.java
@@ -28,4 +28,10 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
 
     // 메시지함 즐겨찾기한 메시지 조회용
     Slice<Message> findByUserIdAndFavorite(Long userId, boolean favorite, Pageable pageable);
+
+    //prev
+    Optional<Message> findTop1ByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long messageId);
+
+    //next
+    Optional<Message> findTop1ByUserIdAndIdGreaterThan(Long userId, Long messageId);
 }

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -233,15 +233,9 @@ public class MessageService {
      */
     public MessageDetailResponseDto getMessageDetail(Long userId, Long messageId) {
 
-        Message message = messageRepository.findByIdAndUserId(messageId, userId).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId));
+        Message message = messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, userId, false).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId));
 
-        MessageBoxResponseDto boxResponseDto;
-        if (message.isAnonymous()) {
-            boxResponseDto = new MessageBoxResponseDto(message, "익명", "기본이미지");
-        } else {
-            SendUserDto sender = userService.findBySenderId(message.getSenderId());
-            boxResponseDto = MessageBoxResponseDto.of(message, sender);
-        }
+        MessageBoxResponseDto boxResponseDto = MessageBoxResponseDto.of(message, userService.findBySenderId(message.getSenderId()));
 
         Long prevId = messageRepository.findTop1ByUserIdAndIdLessThanOrderByIdDesc(userId, messageId)
                 .map(Message::getId)

--- a/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
@@ -202,4 +202,18 @@ class MessageControllerTest extends ControllerTest {
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }
+
+    @DisplayName("메세지 상세 조회 - 존재하지 않는 messageId 예외처리")
+    @Test
+    void getMessageDetail() throws Exception {
+
+        given(messageService.getMessageDetail(anyLong(),eq(1L))).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
+
+        mockMvc.perform(get("/api/messages/1")
+                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("M001"))
+                .andExpect(jsonPath("$.message").value("메세지가 존재하지 않습니다."));
+    }
 }

--- a/src/test/java/com/yapp/betree/repository/MessageRepositoryTest.java
+++ b/src/test/java/com/yapp/betree/repository/MessageRepositoryTest.java
@@ -11,8 +11,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
 @DisplayName("메시지 레파지토리 테스트")
@@ -59,5 +61,41 @@ public class MessageRepositoryTest {
 
         List<Message> messages = messageRepository.findAllByUserIdAndFavorite(user.getId(), true);
         assertThat(messages).hasSize(1);
+    }
+
+    @DisplayName("이전 , 다음 메세지 조회 테스트")
+    @Test
+    void findPrevNextMessageTest() {
+        User user = UserTest.TEST_SAVE_USER;
+        user.addFolder(FolderTest.TEST_DEFAULT_TREE);
+        userRepository.save(user);
+
+        Message message1 = Message.builder()
+                .content("안녕1")
+                .senderId(user.getId())
+                .anonymous(false)
+                .alreadyRead(true)
+                .favorite(true)
+                .opening(false)
+                .user(user)
+                .build();
+        messageRepository.save(message1);
+
+        Message message2 = Message.builder()
+                .content("안녕2")
+                .senderId(user.getId())
+                .anonymous(false)
+                .alreadyRead(true)
+                .favorite(false)
+                .opening(false)
+                .user(user)
+                .build();
+        messageRepository.save(message2);
+
+        Optional<Message> prevMessage = messageRepository.findTop1ByUserIdAndIdLessThanOrderByIdDesc(user.getId(), message1.getId());
+        Optional<Message> nextMessage = messageRepository.findTop1ByUserIdAndIdGreaterThan(user.getId(), message1.getId());
+
+        assertThatThrownBy(prevMessage::get).isInstanceOf(NoSuchElementException.class);
+        assertThat(nextMessage.get().getId()).isEqualTo(message2.getId());
     }
 }

--- a/src/test/java/com/yapp/betree/service/MessageServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/MessageServiceTest.java
@@ -165,7 +165,7 @@ public class MessageServiceTest {
     @DisplayName("메세지 상세 조회 - 존재하지 않는 messageId 입력시 예외 발생")
     void detailMessageNotFound() {
 
-        given(messageRepository.findByIdAndUserId(10L, TEST_SAVE_USER.getId())).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
+        given(messageRepository.findByIdAndUserIdAndDelByReceiver(10L, TEST_SAVE_USER.getId(), false)).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
 
         assertThatThrownBy(() -> messageService.getMessageDetail(TEST_SAVE_USER.getId(), 10L))
                 .isInstanceOf(BetreeException.class)

--- a/src/test/java/com/yapp/betree/service/MessageServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/MessageServiceTest.java
@@ -164,4 +164,15 @@ public class MessageServiceTest {
                 .isInstanceOf(BetreeException.class)
                 .hasMessageContaining("메세지가 존재하지 않습니다.");
     }
+
+    @Test
+    @DisplayName("메세지 상세 조회 - 존재하지 않는 messageId 입력시 예외 발생")
+    void detailMessageNotFound() {
+
+        given(messageRepository.findByIdAndUserId(10L, TEST_SAVE_USER.getId())).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
+
+        assertThatThrownBy(() -> messageService.getMessageDetail(TEST_SAVE_USER.getId(), 10L))
+                .isInstanceOf(BetreeException.class)
+                .hasMessageContaining("메세지가 존재하지 않습니다.");
+    }
 }


### PR DESCRIPTION
## 이슈
- #54

## 작업 내용
- 메세지 상세 조회 api 추가
- MessageDetailResponseDto 추가
- 

## 기타 사항
- 익명일때 발신자 정보 처리하는 부분 stream으로 해보려고 했는데 머리가 안 돌아가서 후에 리팩토링 해보겠습니다..
- 삭제 머지후에 jpa 바뀐 부분 수정하고 다시 푸시할게요
- 추가로 즐겨찾기 메세지 목록 조회도 익명 처리 수정해야겠더라구요 이것도 머지 되면 수정할게요..!

## 체크리스트
- [ ] example