### PR TITLE
feat: 로그아웃 구현

### DIFF
--- a/src/main/java/com/yapp/betree/controller/OAuthController.java
+++ b/src/main/java/com/yapp/betree/controller/OAuthController.java
@@ -1,5 +1,7 @@
 package com.yapp.betree.controller;
 
+import com.yapp.betree.annotation.LoginUser;
+import com.yapp.betree.dto.LoginUserDto;
 import com.yapp.betree.dto.oauth.JwtTokenDto;
 import com.yapp.betree.exception.BetreeException;
 import com.yapp.betree.exception.ErrorCode;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -97,5 +100,26 @@ public class OAuthController {
         response.setHeader(SET_COOKIE_HEADER, cookie.toString());
         response.setHeader(AUTHORIZATION_HEADER, AUTH_TYPE + token.getAccessToken());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+
+    @ApiOperation(value = "로그아웃", notes = "로그아웃, refresh Token 만료")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "[U007]이미 로그아웃된 유저입니다.\n")
+    })
+    @PostMapping("/api/logout")
+    public ResponseEntity<Void> logout(@ApiIgnore @LoginUser LoginUserDto loginUser, HttpServletResponse response) {
+        log.info("[로그아웃 요청] user : {}", loginUser);
+        loginService.logout(loginUser.getId());
+
+        ResponseCookie cookie = ResponseCookie.from(COOKIE_REFRESH_TOKEN, null)
+                .maxAge(0)
+                .path("/")
+                .secure(true)
+                .sameSite("None")
+                .httpOnly(true)
+                .build();
+        response.setHeader(SET_COOKIE_HEADER, cookie.toString());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/yapp/betree/controller/OAuthController.java
+++ b/src/main/java/com/yapp/betree/controller/OAuthController.java
@@ -13,7 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,7 +50,7 @@ public class OAuthController {
                     "[O001]OAuth로 받아온 유저정보가 올바르지 않습니다. - 이메일 누락 등 \n" +
                     "[O002]OAuth로 받아온 액세스 토큰이 만료되었습니다.\n"),
     })
-    @GetMapping("/api/signin")
+    @PostMapping("/api/signin")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Void> signIn(@RequestHeader("X-Kakao-Access-Token") String accessToken, HttpServletResponse response) {
         log.info("회원 로그인 요청 accessToken: {}", accessToken);
@@ -66,7 +66,7 @@ public class OAuthController {
                     "[U004]유효하지 않은 JWT 리프레시 토큰입니다. 재로그인이 필요합니다.\n"),
             @ApiResponse(code = 404, message = "[U005]회원을 찾을 수 없습니다.")
     })
-    @GetMapping("/api/refresh-token")
+    @PostMapping("/api/refresh-token")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Void> refreshToken(HttpServletRequest request, HttpServletResponse response) {
         if (Objects.isNull(request.getCookies())) {

--- a/src/main/java/com/yapp/betree/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/betree/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     USER_REFRESH_ERROR(401,"U004", "유효하지 않은 JWT 리프레시 토큰입니다. 재로그인이 필요합니다."),
     USER_NOT_FOUND(404, "U005", "회원을 찾을 수 없습니다."),
     USER_FORBIDDEN(403,"U006","잘못된 접근입니다."),
+    USER_ALREADY_LOGOUT_TOKEN(200, "U007", "이미 로그아웃된 유저입니다."),
 
     // NoticeTree
     NOTICE_TREE_ERROR(400,"N001","회원의 알림나무 리스트를 불러오는데 실패했습니다."),

--- a/src/main/java/com/yapp/betree/service/LoginService.java
+++ b/src/main/java/com/yapp/betree/service/LoginService.java
@@ -15,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+import static com.yapp.betree.exception.ErrorCode.USER_NOT_FOUND;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -57,5 +59,12 @@ public class LoginService {
         }
         User user = userService.findById(userId).orElseThrow(() -> new BetreeException(ErrorCode.USER_NOT_FOUND, "userId = " + userId));
         return jwtTokenProvider.refreshToken(LoginUserDto.of(user), refreshToken);
+    }
+
+    @Transactional
+    public void
+    logout(Long userId) {
+        userService.findById(userId).orElseThrow(() -> new BetreeException(USER_NOT_FOUND, "userId = "+userId));
+        userService.deleteRefreshToken(userId);
     }
 }

--- a/src/main/java/com/yapp/betree/service/UserService.java
+++ b/src/main/java/com/yapp/betree/service/UserService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+import static com.yapp.betree.exception.ErrorCode.USER_ALREADY_LOGOUT_TOKEN;
 import static com.yapp.betree.exception.ErrorCode.USER_NOT_FOUND;
 
 @Service
@@ -76,5 +77,16 @@ public class UserService {
 
     public boolean isExist(Long userId) {
         return findById(userId).isPresent();
+    }
+
+    @Transactional
+    void deleteRefreshToken(Long userId) {
+        Optional<RefreshToken> refreshToken = refreshTokenRepository.findByUserId(userId);
+
+        if (!refreshToken.isPresent()) {
+            throw new BetreeException(USER_ALREADY_LOGOUT_TOKEN, "userId = " + userId);
+        }
+        log.info("[로그아웃] 리프레시 토큰 삭제 userId : {}, refreshToken : {}", userId, refreshToken.get().getToken());
+        refreshTokenRepository.delete(refreshToken.get());
     }
 }

--- a/src/test/java/com/yapp/betree/config/TestConfig.java
+++ b/src/test/java/com/yapp/betree/config/TestConfig.java
@@ -5,9 +5,22 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.ResponseCookie;
+
+import javax.servlet.http.Cookie;
+
+import static com.yapp.betree.controller.OAuthController.COOKIE_REFRESH_TOKEN;
 
 @TestConfiguration
 public class TestConfig {
+    public static Cookie COOKIE_DELETE_TOKEN = new Cookie("refreshToken", null);
+    public static Cookie COOKIE_TOKEN = new Cookie("refreshToken", "cookie");
+    static {
+        COOKIE_DELETE_TOKEN.setMaxAge(0);
+        COOKIE_DELETE_TOKEN.setHttpOnly(true);
+        COOKIE_TOKEN.setMaxAge(100);
+        COOKIE_TOKEN.setHttpOnly(true);
+    }
     @Bean
     public JwtTokenProvider jwtTokenProvider() {
         return new JwtTokenProvider("secretKey", 6000L, 6000L) {

--- a/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
@@ -93,7 +93,7 @@ public class AcceptanceTest {
         given(kakaoApiService.getOauthId("accessToken")).willReturn(save.getId());
         given(kakaoApiService.getUserInfo("accessToken")).willReturn(oAuthUserInfo);
 
-        mockMvc.perform(get("/api/signin")
+        mockMvc.perform(post("/api/signin")
                 .header("X-Kakao-Access-Token", "accessToken"))
                 .andDo(print())
                 .andExpect(status().isCreated());

--- a/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.yapp.betree.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yapp.betree.config.TestConfig;
 import com.yapp.betree.domain.Folder;
 import com.yapp.betree.domain.FolderTest;
 import com.yapp.betree.domain.FruitType;
@@ -35,6 +36,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
+import javax.servlet.http.Cookie;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -297,6 +300,7 @@ public class AcceptanceTest {
         // 알림나무 조회
         MvcResult mvcResult = mockMvc.perform(get("/api/notices")
                 .contentType(MediaType.APPLICATION_JSON)
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + token))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -310,6 +314,7 @@ public class AcceptanceTest {
         mockMvc.perform(put("/api/messages/alreadyRead")
                 .contentType(MediaType.APPLICATION_JSON)
                 .param("messageId", String.valueOf(message1.getId()))
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + token))
                 .andDo(print())
                 .andExpect(status().isNoContent())
@@ -317,6 +322,7 @@ public class AcceptanceTest {
         mockMvc.perform(put("/api/messages/alreadyRead")
                 .contentType(MediaType.APPLICATION_JSON)
                 .param("messageId", String.valueOf(message2.getId()))
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + token))
                 .andDo(print())
                 .andExpect(status().isNoContent())
@@ -324,6 +330,7 @@ public class AcceptanceTest {
 
         MvcResult mvcResult2 = mockMvc.perform(get("/api/notices")
                 .contentType(MediaType.APPLICATION_JSON)
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + token))
                 .andDo(print())
                 .andExpect(status().isOk())

--- a/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
@@ -1,6 +1,7 @@
 package com.yapp.betree.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yapp.betree.config.TestConfig;
 import com.yapp.betree.domain.FruitType;
 import com.yapp.betree.domain.MessageTest;
 import com.yapp.betree.dto.SendUserDto;
@@ -121,6 +122,7 @@ public class ForestControllerTest extends ControllerTest {
         mockMvc.perform(post("/api/forest")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(input))
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$").value(1L))
@@ -138,6 +140,7 @@ public class ForestControllerTest extends ControllerTest {
         mockMvc.perform(post("/api/forest")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(input))
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("T002"))
@@ -155,6 +158,7 @@ public class ForestControllerTest extends ControllerTest {
         mockMvc.perform(post("/api/forest")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(input))
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("C001"))
@@ -173,6 +177,7 @@ public class ForestControllerTest extends ControllerTest {
         mockMvc.perform(post("/api/forest")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(input))
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("C001"))
@@ -191,6 +196,7 @@ public class ForestControllerTest extends ControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .param("userId", String.valueOf(1L))
                 .content(objectMapper.writeValueAsString(input))
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -212,6 +218,7 @@ public class ForestControllerTest extends ControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .param("userId", String.valueOf(1L))
                 .content(objectMapper.writeValueAsString(input))
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
@@ -229,6 +236,7 @@ public class ForestControllerTest extends ControllerTest {
         mockMvc.perform(put("/api/forest/18")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(input))
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("C001"))
@@ -246,6 +254,7 @@ public class ForestControllerTest extends ControllerTest {
         mockMvc.perform(put("/api/forest/18")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(input))
+                .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("C001"))

--- a/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
@@ -1,6 +1,7 @@
 package com.yapp.betree.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yapp.betree.config.TestConfig;
 import com.yapp.betree.dto.request.MessageRequestDto;
 import com.yapp.betree.dto.response.MessageBoxResponseDto;
 import com.yapp.betree.dto.response.MessagePageResponseDto;
@@ -52,9 +53,10 @@ class MessageControllerTest extends ControllerTest {
         given(messageService.createMessage(anyLong(), any())).willReturn(1L);
 
         mockMvc.perform(post("/api/messages")
-                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$").value(1L));
@@ -72,9 +74,10 @@ class MessageControllerTest extends ControllerTest {
         given(messageService.createMessage(anyLong(), any())).willReturn(1L);
 
         mockMvc.perform(post("/api/messages")
-                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("C001"))
@@ -93,9 +96,10 @@ class MessageControllerTest extends ControllerTest {
         given(messageService.getMessageList(anyLong(), any(), anyLong())).willReturn(MessagePageResponseDto.of(messageDto, false));
 
         mockMvc.perform(get("/api/messages")
-                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
-                        .param("page", String.valueOf(0))
-                        .param("treeId", String.valueOf(19L)))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
+                .param("page", String.valueOf(0))
+                .param("treeId", String.valueOf(19L)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.responseDto.length()").value(2))
@@ -111,9 +115,10 @@ class MessageControllerTest extends ControllerTest {
         given(messageService.getMessageList(anyLong(), any(), eq(19L))).willThrow(new BetreeException(ErrorCode.TREE_NOT_FOUND));
 
         mockMvc.perform(get("/api/messages")
-                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
-                        .param("page", String.valueOf(0))
-                        .param("treeId", String.valueOf(19L)))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
+                .param("page", String.valueOf(0))
+                .param("treeId", String.valueOf(19L)))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("T001"))
@@ -128,9 +133,10 @@ class MessageControllerTest extends ControllerTest {
         List<String> idList = Arrays.asList(String.valueOf(9L), String.valueOf(10L));
 
         mockMvc.perform(put("/api/messages/opening")
-                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(idList)))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(idList)))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }
@@ -143,9 +149,10 @@ class MessageControllerTest extends ControllerTest {
         List<String> idList = Arrays.asList(String.valueOf(9L), String.valueOf(10L));
 
         mockMvc.perform(delete("/api/messages")
-                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(idList)))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(idList)))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }
@@ -157,10 +164,11 @@ class MessageControllerTest extends ControllerTest {
         List<String> idList = Arrays.asList(String.valueOf(9L), String.valueOf(10L));
 
         mockMvc.perform(put("/api/messages/folder")
-                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(idList))
-                        .param("treeId", String.valueOf(1L)))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(idList))
+                .param("treeId", String.valueOf(1L)))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }
@@ -170,8 +178,9 @@ class MessageControllerTest extends ControllerTest {
     void updateMessageFavorite() throws Exception {
 
         mockMvc.perform(put("/api/messages/favorite")
-                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
-                        .param("messageId", String.valueOf(1L)))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
+                .param("messageId", String.valueOf(1L)))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }
@@ -185,8 +194,9 @@ class MessageControllerTest extends ControllerTest {
         given(messageService.getFavoriteMessage(anyLong(), any())).willReturn(MessagePageResponseDto.of(messageDto, false));
 
         mockMvc.perform(get("/api/messages/favorite")
-                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
-                        .param("page", String.valueOf(0)))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
+                .param("page", String.valueOf(0)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.responseDto[0].favorite").value(true));
@@ -197,8 +207,9 @@ class MessageControllerTest extends ControllerTest {
     void updateMessageRead() throws Exception {
 
         mockMvc.perform(put("/api/messages/alreadyRead")
-                        .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
-                        .param("messageId", String.valueOf(1L)))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
+                .param("messageId", String.valueOf(1L)))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }

--- a/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
@@ -1,9 +1,13 @@
 package com.yapp.betree.controller;
 
 import com.yapp.betree.dto.oauth.JwtTokenDto;
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.exception.ErrorCode;
+import com.yapp.betree.service.JwtTokenTest;
 import com.yapp.betree.service.LoginService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -12,6 +16,8 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.reactive.function.client.WebClientException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -80,5 +86,34 @@ public class OAuthControllerTest extends ControllerTest {
 
         assertThat(mvcResult.getResponse().getCookie("refreshToken").getValue()).isEqualTo("betreeRefreshToken");
         assertThat(mvcResult.getResponse().getHeader("Authorization")).isEqualTo("Bearer betreeAccessToken");
+    }
+
+    @Test
+    @DisplayName("로그아웃 - 성공하면 쿠키에 토큰이 지워진다.")
+    void logoutTest() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(post("/api/logout")
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        assertThat(mvcResult.getResponse().getCookie("refreshToken").getValue()).isBlank();
+        assertThat(mvcResult.getResponse().getCookie("refreshToken").getMaxAge()).isZero();
+        assertThat(mvcResult.getResponse().getHeader("Authorization")).isNull();
+    }
+
+    @Test
+    @DisplayName("로그아웃 - 이미 로그아웃된 유저는 예외메시지를 반환한다.")
+    void alreadyLogoutTest() throws Exception {
+        willThrow(new BetreeException(ErrorCode.USER_ALREADY_LOGOUT_TOKEN)).given(loginService).logout(1L);
+        MvcResult mvcResult = mockMvc.perform(post("/api/logout")
+                .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("U007"))
+                .andDo(print())
+                .andReturn();
+
+        assertThat(mvcResult.getResponse().getCookie("refreshToken")).isNull();
+        assertThat(mvcResult.getResponse().getHeader("Authorization")).isNull();
     }
 }

--- a/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.web.reactive.function.client.WebClientException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,7 +38,7 @@ public class OAuthControllerTest extends ControllerTest {
     @Test
     @DisplayName("회원가입,로그인 - 헤더에 AccessToken이 없으면 예외가 발생한다.")
     void headerAccessTokenNullTest() throws Exception {
-        mockMvc.perform(get("/api/signin"))
+        mockMvc.perform(post("/api/signin"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("code").value("C001"))
                 .andDo(print());
@@ -49,7 +50,7 @@ public class OAuthControllerTest extends ControllerTest {
         String accessToken = "accessToken";
         given(loginService.createToken(accessToken)).willThrow(new KakaoWebClientException("401"));
 
-        mockMvc.perform(get("/api/signin")
+        mockMvc.perform(post("/api/signin")
                 .header("X-Kakao-Access-Token", accessToken))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("code").value("O000"))
@@ -71,7 +72,7 @@ public class OAuthControllerTest extends ControllerTest {
                 .refreshToken("betreeRefreshToken")
                 .build());
 
-        MvcResult mvcResult = mockMvc.perform(get("/api/signin")
+        MvcResult mvcResult = mockMvc.perform(post("/api/signin")
                 .header("X-Kakao-Access-Token", accessToken))
                 .andExpect(status().isCreated())
                 .andDo(print())

--- a/src/test/java/com/yapp/betree/interceptor/TokenInterceptorTest.java
+++ b/src/test/java/com/yapp/betree/interceptor/TokenInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.yapp.betree.interceptor;
 
+import com.yapp.betree.config.TestConfig;
 import com.yapp.betree.domain.UserTest;
 import com.yapp.betree.dto.LoginUserDto;
 import com.yapp.betree.dto.oauth.JwtTokenDto;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
+
+import javax.servlet.http.Cookie;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -63,6 +66,7 @@ public class TokenInterceptorTest {
     private MockHttpServletRequest jwtAuthHttpRequest(String token) {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        request.setCookies(TestConfig.COOKIE_TOKEN);
         return request;
     }
 }

--- a/src/test/java/com/yapp/betree/service/UserServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/UserServiceTest.java
@@ -1,7 +1,8 @@
 package com.yapp.betree.service;
 
 import com.yapp.betree.domain.User;
-import com.yapp.betree.domain.UserTest;
+import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.repository.RefreshTokenRepository;
 import com.yapp.betree.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ import java.util.Optional;
 import static com.yapp.betree.domain.UserTest.TEST_SAVE_USER;
 import static com.yapp.betree.domain.UserTest.TEST_USER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,6 +28,9 @@ public class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
 
     @Test
     @DisplayName("oauthId를 통해 User를 얻어낼 수 있다.")
@@ -80,5 +85,16 @@ public class UserServiceTest {
 
         // then
         assertThat(exist).isFalse();
+    }
+
+    @Test
+    @DisplayName("로그아웃 테스트 - 이미 로그아웃된 유저 처리")
+    void logoutUserTest() {
+        Long userId = 1L;
+        given(refreshTokenRepository.findByUserId(userId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.deleteRefreshToken(userId))
+                .isInstanceOf(BetreeException.class)
+                .hasMessageContaining("이미 로그아웃된 유저입니다.");
     }
 }


### PR DESCRIPTION
## 이슈
- #55 
## 작업 내용
- 로그인관련 메서드 (로그인/회원가입, 리프레시토큰으로 토큰재발급) HTTP method POST로 변경
- 로그아웃 구현
  - refreshToken 테이블에 userId에 해당하는 refreshToken 삭제, 예외처리 
  - httpOnly cookie에 key가 "refreshToken"인 쿠키 유효시간 0, 토큰값 null넣어 초기화
  - 헤더에 refreshToken이름을 가진 쿠키가 없거나 이미 로그아웃 처리 된 쿠키일 경우 예외처리 
     - 다시 로그아웃 API 요청한 경우 이미 로그아웃 되었다는 메시지 보냄 (실패는 아니니깐 HTTP status 는 200)
     - 나머지 요청은 에러처리 인터셉터에서 throw new 하는게 잘 안돼서 response.sendError로 처리함

## 기타 사항
- 앞으로 컨트롤러 테스트코드에 header에는 jwt token, cookie에는 `TestConfig.COOKIE_TOKEN` 추가해주어야 요청 성공함 
- 나중에 중복로그인 처리는 따로 고민해야함. 지금은 1아이디 1로그인만 가능해질듯 

## 체크리스트
- [x] 테스트 성공