### PR TITLE
bug: 리프레시토큰 쿠키 검증으로 api요청 안되는 오류 임시 해결

### DIFF
--- a/src/main/java/com/yapp/betree/controller/OAuthController.java
+++ b/src/main/java/com/yapp/betree/controller/OAuthController.java
@@ -71,16 +71,18 @@ public class OAuthController {
     })
     @PostMapping("/api/refresh-token")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<Void> refreshToken(HttpServletRequest request, HttpServletResponse response) {
-        if (Objects.isNull(request.getCookies())) {
-            throw new BetreeException(ErrorCode.USER_REFRESH_ERROR, "쿠키에 토큰이 존재하지 않습니다.");
-        }
+    public ResponseEntity<Void> refreshToken(
+            @RequestHeader("X-refresh-Token") String refreshToken,
+            HttpServletRequest request, HttpServletResponse response) {
+//        if (Objects.isNull(request.getCookies())) {
+//            throw new BetreeException(ErrorCode.USER_REFRESH_ERROR, "쿠키에 토큰이 존재하지 않습니다.");
+//        }
 
-        String refreshToken = Arrays.stream(request.getCookies())
-                .filter(cookie -> COOKIE_REFRESH_TOKEN.equals(cookie.getName()))
-                .findAny()
-                .orElseThrow(() -> new BetreeException(ErrorCode.USER_REFRESH_ERROR, "쿠키에 토큰이 존재하지 않습니다."))
-                .getValue();
+//        String refreshToken = Arrays.stream(request.getCookies())
+//                .filter(cookie -> COOKIE_REFRESH_TOKEN.equals(cookie.getName()))
+//                .findAny()
+//                .orElseThrow(() -> new BetreeException(ErrorCode.USER_REFRESH_ERROR, "쿠키에 토큰이 존재하지 않습니다."))
+//                .getValue();
 
         log.info("회원 토큰 재발급 요청 refreshToken: {}", refreshToken);
         JwtTokenDto token = loginService.refreshToken(refreshToken);
@@ -93,8 +95,8 @@ public class OAuthController {
         ResponseCookie cookie = ResponseCookie.from(COOKIE_REFRESH_TOKEN, token.getRefreshToken())
                 .maxAge(24 * 60 * 60 * 7)
                 .path("/")
-//                .secure(true)
-//                .sameSite("None")
+                .secure(true)
+                .sameSite("None")
 //                .httpOnly(true)
                 .build();
         response.setHeader(SET_COOKIE_HEADER, cookie.toString());
@@ -115,8 +117,8 @@ public class OAuthController {
         ResponseCookie cookie = ResponseCookie.from(COOKIE_REFRESH_TOKEN, null)
                 .maxAge(0)
                 .path("/")
-//                .secure(true)
-//                .sameSite("None")
+                .secure(true)
+                .sameSite("None")
 //                .httpOnly(true)
                 .build();
         response.setHeader(SET_COOKIE_HEADER, cookie.toString());

--- a/src/main/java/com/yapp/betree/interceptor/TokenInterceptor.java
+++ b/src/main/java/com/yapp/betree/interceptor/TokenInterceptor.java
@@ -44,12 +44,14 @@ public class TokenInterceptor implements HandlerInterceptor {
         String authHeader = Optional.ofNullable(request.getHeader("Authorization"))
                 .orElseThrow(() -> new BetreeException(ErrorCode.USER_TOKEN_ERROR, "헤더에 토큰이 존재하지 않습니다."));
 
+
         if (isInvalidRefreshToken(request.getCookies())) {
+            log.info("[리프레시토큰 검증] 비어있어도 테스트기간 동안은 통과"); // TODO 주석 제거
             if (request.getRequestURI().equals("/api/logout")) {
                 throw new BetreeException(ErrorCode.USER_ALREADY_LOGOUT_TOKEN);
             }
-            response.sendError(ErrorCode.USER_REFRESH_ERROR.getStatus(), ErrorCode.USER_REFRESH_ERROR.getMessage());
-            return false;
+//            response.sendError(ErrorCode.USER_REFRESH_ERROR.getStatus(), ErrorCode.USER_REFRESH_ERROR.getMessage());
+//            return false;
         }
 
         if (authHeader.startsWith(AUTH_TYPE)) {

--- a/src/main/java/com/yapp/betree/service/NoticeTreeService.java
+++ b/src/main/java/com/yapp/betree/service/NoticeTreeService.java
@@ -37,6 +37,7 @@ public class NoticeTreeService {
     private final UserService userService;
 
 
+    @Transactional
     public NoticeResponseDto getUnreadMessages(Long userId) {
         NoticeTree noticeTree = noticeTreeRepository.findByUserId(userId).orElseGet(
                 () -> {

--- a/src/main/java/com/yapp/betree/service/oauth/JwtTokenProvider.java
+++ b/src/main/java/com/yapp/betree/service/oauth/JwtTokenProvider.java
@@ -32,7 +32,7 @@ public class JwtTokenProvider {
                             @Value("${secrets.jwt.token.expiration-time}") Long tokenValidMilliseconds,
                             @Value("${secrets.jwt.token.refresh-expiration-time}") Long refreshTokenValidMilliseconds) {
         this.secretKey = secretKey;
-        this.tokenValidMilliseconds = tokenValidMilliseconds; // 1시간
+        this.tokenValidMilliseconds = tokenValidMilliseconds; // 1시간 -> 임시로 하루
         this.refreshTokenValidMilliseconds = refreshTokenValidMilliseconds * DAYS; // 하루 * days
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,5 +45,5 @@ secrets:
   jwt:
     token:
       secret-key: B1e2t3r4e5e6S7e8c9r0e1t
-      expiration-time: 600000
+      expiration-time: 86400000
       refresh-expiration-time: 86400000

--- a/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/OAuthControllerTest.java
@@ -6,6 +6,7 @@ import com.yapp.betree.exception.BetreeException;
 import com.yapp.betree.exception.ErrorCode;
 import com.yapp.betree.service.JwtTokenTest;
 import com.yapp.betree.service.LoginService;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
@@ -135,6 +136,7 @@ public class OAuthControllerTest extends ControllerTest {
         assertThat(mvcResult.getResponse().getHeader("Authorization")).isNull();
     }
 
+    @Disabled // TODO 임시: 리프레시토큰 검증 삭제
     @Test
     @DisplayName("이미 로그아웃되어 헤더(쿠키)에 리프레시 토큰이 존재하지 않을경우 예외가 발생한다.")
     void refreshTokenCookieNullTest() throws Exception {


### PR DESCRIPTION
## 이슈

## 작업 내용
- 리프레시토큰 검증부분 생략
- 리프레시토큰으로 토큰 갱신하는거는 리프레시토큰 쿠키값 받아와 헤더로 요청할 수 있도록 임시 변경 
- 액세스토큰 24시간으로 변경

## 기타 사항
- transactional 빠져서 알림나무 조회 안되기래 어노테이션 추가함

## 체크리스트
- [x]테스트 성공