### PR TITLE
[bug] DB에서 가져온 알림나무 content에 null들어가는 오류 해결

### DIFF
--- a/src/main/java/com/yapp/betree/util/BetreeUtils.java
+++ b/src/main/java/com/yapp/betree/util/BetreeUtils.java
@@ -30,7 +30,7 @@ public class BetreeUtils {
     }
 
     public static MessageResponseDto getBetreeMessage(Long id) {
-        Long key = id * -1;
+        Long key = id > 0 ? (id * -1) : id;
         String value = betreeMessages.get(key);
 
         Message message = Message.builder()


### PR DESCRIPTION

## 이슈
- 알림나무조회시 content가 비어있음
```json
{
  "totalUnreadMessageCount": 0,
  "messages": [
    {
      "id": 6,
      "anonymous": false,
      "senderNickname": "Betree",
      "senderProfileImage": "Betree 이미지"
    },
    {
      "id": 5,
      "anonymous": false,
      "senderNickname": "Betree",
      "senderProfileImage": "Betree 이미지"
    },,,,
  ]
}
```
## 작업 내용
- - DB에서 가져올 땐 이미 음수로 가져와서 key값 음수보정 안하는 것으로 변경

## 기타 사항

## 체크리스트
- [x] 테스트 확인