### PR TITLE
fix: 5차 스프린트 논의사항 수정

### DIFF
--- a/src/main/java/com/yapp/betree/config/WebConfig.java
+++ b/src/main/java/com/yapp/betree/config/WebConfig.java
@@ -32,7 +32,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new TokenInterceptor(jwtTokenProvider))
                 .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/signin", "/api/refresh-token");
+                .excludePathPatterns("/api/signin", "/api/refresh-token")
+                .excludePathPatterns("/static/**");
     }
 
     @Override

--- a/src/main/java/com/yapp/betree/controller/ForestController.java
+++ b/src/main/java/com/yapp/betree/controller/ForestController.java
@@ -162,7 +162,7 @@ public class ForestController {
      */
     @ApiOperation(value = "유저 나무 삭제", notes = "유저 나무 삭제 - 나무에 포함된 메시지도 모두 삭제")
     @ApiResponses({
-            @ApiResponse(code = 400, message = "[T004]기본 나무를 삭제할 수 없습니다."),
+            @ApiResponse(code = 400, message = "[T002]기본 나무를 생성,변경할 수 없습니다."),
             @ApiResponse(code = 403, message = "[U006]잘못된 접근입니다. 유저와 나무 주인이 일치하지 않습니다."),
             @ApiResponse(code = 404, message = "[U005]회원을 찾을 수 없습니다.\n" +
                     "[T001]나무가 존재하지 않습니다.")
@@ -186,6 +186,7 @@ public class ForestController {
      */
     @ApiOperation(value = "유저 나무 공개 설정", notes = "유저 나무 공개 설정 - 공개/비공개")
     @ApiResponses({
+            @ApiResponse(code = 400, message = "[T002]기본 나무를 생성,변경할 수 없습니다."),
             @ApiResponse(code = 403, message = "[U006]잘못된 접근입니다. 유저와 나무 주인이 일치하지 않습니다."),
             @ApiResponse(code = 404, message = "[U005]회원을 찾을 수 없습니다.\n" +
                     "[T001]나무가 존재하지 않습니다.")

--- a/src/main/java/com/yapp/betree/domain/Folder.java
+++ b/src/main/java/com/yapp/betree/domain/Folder.java
@@ -56,6 +56,9 @@ public class Folder extends BaseTimeEntity {
         this.user = user;
     }
 
+    public boolean isDefault() {
+        return this.fruit == FruitType.DEFAULT;
+    }
 
     public void updateUser(User user) {
         this.user = user;
@@ -65,10 +68,6 @@ public class Folder extends BaseTimeEntity {
      * 나무 편집 메서드
      */
     public void update(String name, FruitType fruit) {
-        // DEFAULT 나무일 경우 수정 불가능
-        if (this.fruit == FruitType.DEFAULT) {
-            throw new BetreeException(ErrorCode.TREE_DEFAULT_ERROR, "treeId = " + id);
-        }
         if (fruit == FruitType.DEFAULT) {
             throw new BetreeException(ErrorCode.TREE_DEFAULT_ERROR, "변경할 타입을 기본 나무 이외의 다른 나무로 선택해주세요. treeId = " + id + ", FruitType = " + fruit);
         }

--- a/src/main/java/com/yapp/betree/dto/SendUserDto.java
+++ b/src/main/java/com/yapp/betree/dto/SendUserDto.java
@@ -35,7 +35,7 @@ public class SendUserDto {
         return SendUserDto.builder()
                 .id(-1L)
                 .nickname("익명")
-                .userImage("기본이미지")
+                .userImage("")
                 .build();
     }
 }

--- a/src/main/java/com/yapp/betree/dto/SendUserDto.java
+++ b/src/main/java/com/yapp/betree/dto/SendUserDto.java
@@ -1,6 +1,7 @@
 package com.yapp.betree.dto;
 
 import com.yapp.betree.domain.User;
+import com.yapp.betree.util.BetreeUtils;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,7 +28,7 @@ public class SendUserDto {
         return SendUserDto.builder()
                 .id(user.getId())
                 .nickname(user.getNickname())
-                .userImage(user.getUserImage())
+                .userImage(BetreeUtils.getImageUrl(user.getUserImage()))
                 .build();
     }
 
@@ -35,7 +36,7 @@ public class SendUserDto {
         return SendUserDto.builder()
                 .id(-1L)
                 .nickname("익명")
-                .userImage("")
+                .userImage(BetreeUtils.getImageUrl("-1"))
                 .build();
     }
 }

--- a/src/main/java/com/yapp/betree/dto/oauth/OAuthUserInfoDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/OAuthUserInfoDto.java
@@ -43,7 +43,7 @@ public class OAuthUserInfoDto {
                 .oauthId(id)
                 .nickname(nickname)
                 .email(email)
-                .userImage("default image uri") // TODO uri 결정
+                .userImage(BetreeUtils.makeUserImage())
                 .lastAccessTime(LocalDateTime.now())
                 .url(BetreeUtils.makeUserAccessUrl(this))
                 .build();

--- a/src/main/java/com/yapp/betree/dto/oauth/OAuthUserInfoDto.java
+++ b/src/main/java/com/yapp/betree/dto/oauth/OAuthUserInfoDto.java
@@ -43,7 +43,7 @@ public class OAuthUserInfoDto {
                 .oauthId(id)
                 .nickname(nickname)
                 .email(email)
-                .userImage(BetreeUtils.makeUserImage())
+                .userImage(BetreeUtils.makeUserImageNumber())
                 .lastAccessTime(LocalDateTime.now())
                 .url(BetreeUtils.makeUserAccessUrl(this))
                 .build();

--- a/src/main/java/com/yapp/betree/dto/response/MessageBoxResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessageBoxResponseDto.java
@@ -3,6 +3,7 @@ package com.yapp.betree.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yapp.betree.domain.Message;
 import com.yapp.betree.dto.SendUserDto;
+import com.yapp.betree.util.BetreeUtils;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -44,7 +45,7 @@ public class MessageBoxResponseDto {
         return MessageBoxResponseDto.builder()
                 .message(message)
                 .senderNickname(message.isAnonymous() ? "익명" : user.getNickname())
-                .senderProfileImage(message.isAnonymous() ? "" : user.getUserImage())
+                .senderProfileImage(BetreeUtils.getImageUrl(message.isAnonymous() ? "-1" : user.getUserImage()))
                 .build();
     }
 }

--- a/src/main/java/com/yapp/betree/dto/response/MessageBoxResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessageBoxResponseDto.java
@@ -44,7 +44,7 @@ public class MessageBoxResponseDto {
         return MessageBoxResponseDto.builder()
                 .message(message)
                 .senderNickname(message.isAnonymous() ? "익명" : user.getNickname())
-                .senderProfileImage(message.isAnonymous() ? "기본 이미지" : user.getUserImage())
+                .senderProfileImage(message.isAnonymous() ? "" : user.getUserImage())
                 .build();
     }
 }

--- a/src/main/java/com/yapp/betree/dto/response/MessageResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessageResponseDto.java
@@ -36,7 +36,7 @@ public class MessageResponseDto {
         return MessageResponseDto.builder()
                 .message(message)
                 .senderNickname(message.isAnonymous() ? "익명" : user.getNickname())
-                .senderProfileImage(message.isAnonymous() ? "기본 이미지" : user.getUserImage())
+                .senderProfileImage(message.isAnonymous() ? "" : user.getUserImage())
                 .build();
     }
 

--- a/src/main/java/com/yapp/betree/dto/response/MessageResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessageResponseDto.java
@@ -3,6 +3,7 @@ package com.yapp.betree.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yapp.betree.domain.Message;
 import com.yapp.betree.dto.SendUserDto;
+import com.yapp.betree.util.BetreeUtils;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,7 +37,7 @@ public class MessageResponseDto {
         return MessageResponseDto.builder()
                 .message(message)
                 .senderNickname(message.isAnonymous() ? "익명" : user.getNickname())
-                .senderProfileImage(message.isAnonymous() ? "" : user.getUserImage())
+                .senderProfileImage(BetreeUtils.getImageUrl(message.isAnonymous() ? "-1" : user.getUserImage()))
                 .build();
     }
 

--- a/src/main/java/com/yapp/betree/dto/response/UserResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/UserResponseDto.java
@@ -1,6 +1,7 @@
 package com.yapp.betree.dto.response;
 
 import com.yapp.betree.domain.User;
+import com.yapp.betree.util.BetreeUtils;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,7 +31,7 @@ public class UserResponseDto {
                 .id(user.getId())
                 .nickname(user.getNickname())
                 .email(user.getEmail())
-                .userImage(user.getUserImage())
+                .userImage(BetreeUtils.getImageUrl(user.getUserImage()))
                 .url(user.getUrl())
                 .build();
     }

--- a/src/main/java/com/yapp/betree/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/betree/exception/ErrorCode.java
@@ -21,7 +21,6 @@ public enum ErrorCode {
     TREE_NOT_FOUND(404,"T001", "나무가 존재하지 않습니다."),
     TREE_DEFAULT_ERROR(400,"T002","기본 나무를 생성,변경 할 수 없습니다."),
     TREE_COUNT_ERROR(400,"T003","나무는 최대 4개까지 추가 가능합니다."),
-    TREE_DEFAULT_DELETE_ERROR(400, "T004", "기본 나무를 삭제할 수 없습니다."),
 
     //Message
     MESSAGE_NOT_FOUND(404,"M001", "메세지가 존재하지 않습니다."),

--- a/src/main/java/com/yapp/betree/repository/MessageRepository.java
+++ b/src/main/java/com/yapp/betree/repository/MessageRepository.java
@@ -31,8 +31,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findAllByUserIdAndFolderIdAndDelByReceiver(Long userId, Long folderId, boolean delByReceiver);
 
     //prev
-    Optional<Message> findTop1ByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long messageId);
+    Optional<Message> findTop1ByUserIdAndFolderIdAndIdLessThanOrderByIdDesc(Long userId, Long folderId, Long messageId);
 
     //next
-    Optional<Message> findTop1ByUserIdAndIdGreaterThan(Long userId, Long messageId);
+    Optional<Message> findTop1ByUserIdAndFolderIdAndIdGreaterThan(Long userId, Long folderId, Long messageId);
 }

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -242,10 +242,11 @@ public class MessageService {
 
         MessageBoxResponseDto boxResponseDto = MessageBoxResponseDto.of(message, userService.findBySenderId(message.getSenderId()));
 
-        Long prevId = messageRepository.findTop1ByUserIdAndIdLessThanOrderByIdDesc(userId, messageId)
+        Long folderId = message.getFolder().getId();
+        Long prevId = messageRepository.findTop1ByUserIdAndFolderIdAndIdLessThanOrderByIdDesc(userId, folderId, messageId)
                 .map(Message::getId)
                 .orElse(0L);
-        Long nextId = messageRepository.findTop1ByUserIdAndIdGreaterThan(userId, messageId)
+        Long nextId = messageRepository.findTop1ByUserIdAndFolderIdAndIdGreaterThan(userId, folderId, messageId)
                 .map(Message::getId)
                 .orElse(0L);
 

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -220,8 +220,12 @@ public class MessageService {
     @Transactional
     public void updateReadMessage(Long userId, Long messageId) {
 
-        messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, userId, false).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId))
-                .updateAlreadyRead();
+        User user = userRepository.findById(userId).orElseThrow(() -> new BetreeException(USER_NOT_FOUND, "userId = " + userId));
+
+        if (messageId > 0L) { // 비트리에서 보내준 메시지(id가 음수)일 경우는 읽음처리 제외
+            messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, userId, false).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId))
+                    .updateAlreadyRead();
+        }
         noticeTreeService.updateNoticeTree(userId, messageId);
     }
 

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -106,7 +106,7 @@ public class MessageService {
         //익명인 메세지 저장 구분
         for (Message message : messages) {
             if (message.isAnonymous()) {
-                responseDtos.add(new MessageBoxResponseDto(message, "익명", "기본이미지"));
+                responseDtos.add(new MessageBoxResponseDto(message, "익명", ""));
             } else {
                 SendUserDto sender = userService.findBySenderId(message.getSenderId());
                 responseDtos.add(MessageBoxResponseDto.of(message, sender));

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -106,7 +106,7 @@ public class MessageService {
         //익명인 메세지 저장 구분
         for (Message message : messages) {
             if (message.isAnonymous()) {
-                responseDtos.add(new MessageBoxResponseDto(message, "익명", ""));
+                responseDtos.add(new MessageBoxResponseDto(message, "익명", "1"));
             } else {
                 SendUserDto sender = userService.findBySenderId(message.getSenderId());
                 responseDtos.add(MessageBoxResponseDto.of(message, sender));

--- a/src/main/java/com/yapp/betree/util/BetreeUtils.java
+++ b/src/main/java/com/yapp/betree/util/BetreeUtils.java
@@ -4,10 +4,14 @@ import com.yapp.betree.domain.Message;
 import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
 import com.yapp.betree.dto.response.MessageResponseDto;
 
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class BetreeUtils {
 
+    private static final Random RANDOM = new Random();
+    private static final int RANDOM_BOUND = 4;
+    private static final int RANDOM_MIN = 1;
     public static final ConcurrentHashMap<Long, String> betreeMessages = new ConcurrentHashMap<Long, String>() {{
         put(-1L, "칭찬메시지1");
         put(-2L, "칭찬메시지2");
@@ -20,13 +24,17 @@ public class BetreeUtils {
 
     }};
 
-    // TODO 유저 접속 URL 생성 필요
+    // 접속 URL ""로 리턴 -> 프론트에서 알아서 처리
     public static String makeUserAccessUrl(OAuthUserInfoDto user) {
-        return "accessUrl";
+        return "";
     }
 
-    public static String makeUserAccessUrl(Long oauthId) {
-        return "accessUrl";
+    public static String makeUserAccessUrl(Long id) {
+        return "";
+    }
+
+    public static String makeUserImage() {
+        return String.valueOf(RANDOM.nextInt(RANDOM_BOUND) + RANDOM_MIN);
     }
 
     public static MessageResponseDto getBetreeMessage(Long id) {
@@ -45,7 +53,7 @@ public class BetreeUtils {
         return MessageResponseDto.builder()
                 .message(message)
                 .senderNickname("Betree")
-                .senderProfileImage("Betree 이미지")
+                .senderProfileImage("1")
                 .build();
     }
 }

--- a/src/main/java/com/yapp/betree/util/BetreeUtils.java
+++ b/src/main/java/com/yapp/betree/util/BetreeUtils.java
@@ -12,6 +12,8 @@ public class BetreeUtils {
     private static final Random RANDOM = new Random();
     private static final int RANDOM_BOUND = 4;
     private static final int RANDOM_MIN = 1;
+    private static final String BASE_IMAGE_URL = "image/v1/user_";
+    private static final String BASE_IMAGE_SUFFIX = ".png";
     public static final ConcurrentHashMap<Long, String> betreeMessages = new ConcurrentHashMap<Long, String>() {{
         put(-1L, "칭찬메시지1");
         put(-2L, "칭찬메시지2");
@@ -33,8 +35,18 @@ public class BetreeUtils {
         return "";
     }
 
-    public static String makeUserImage() {
+    public static String makeUserImageNumber() {
         return String.valueOf(RANDOM.nextInt(RANDOM_BOUND) + RANDOM_MIN);
+    }
+
+    public static String getImageUrl(String id) {
+        if ("0".equals(id)) {
+            return BASE_IMAGE_URL + "betree" + BASE_IMAGE_SUFFIX;
+        }
+        if ("-1".equals(id)) {
+            return BASE_IMAGE_URL + "unknown" + BASE_IMAGE_SUFFIX;
+        }
+        return BASE_IMAGE_URL + id + BASE_IMAGE_SUFFIX;
     }
 
     public static MessageResponseDto getBetreeMessage(Long id) {
@@ -53,7 +65,7 @@ public class BetreeUtils {
         return MessageResponseDto.builder()
                 .message(message)
                 .senderNickname("Betree")
-                .senderProfileImage("1")
+                .senderProfileImage(getImageUrl("0"))
                 .build();
     }
 }

--- a/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
@@ -334,6 +334,14 @@ public class AcceptanceTest {
                 .andDo(print())
                 .andExpect(status().isNoContent())
                 .andReturn();
+        mockMvc.perform(put("/api/messages/alreadyRead") // 음수메시지
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("messageId", String.valueOf(-1L))
+                .cookie(TestConfig.COOKIE_TOKEN)
+                .header("Authorization", "Bearer " + token))
+                .andDo(print())
+                .andExpect(status().isNoContent())
+                .andReturn();
 
         MvcResult mvcResult2 = mockMvc.perform(get("/api/notices")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -345,7 +353,7 @@ public class AcceptanceTest {
 
         // 읽고나서 조회 -> 읽은만큼 개수 줄어듦
         NoticeResponseDto noticeResponseDto2 = (NoticeResponseDto) objectMapper.readValue(mvcResult2.getResponse().getContentAsString(), NoticeResponseDto.class);
-        assertThat(noticeResponseDto2.getMessages()).hasSize(6);
+        assertThat(noticeResponseDto2.getMessages()).hasSize(5);
         assertThat(noticeResponseDto2.getTotalUnreadMessageCount()).isEqualTo(2);
 
         // 읽은메시지 볼 수 없음

--- a/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
@@ -207,7 +207,7 @@ public class AcceptanceTest {
         , MessageResponseDto(id=-2, content=칭찬메시지2, anonymous=false, senderNickname=Betree, senderProfileImage=Betree 이미지)
         , MessageResponseDto(id=-1, content=칭찬메시지1, anonymous=false, senderNickname=Betree, senderProfileImage=Betree 이미지)
         , MessageResponseDto(id=123, content=보낸메시지3-익명아님,안읽음,즐겨찾기, anonymous=false, senderNickname=닉네임, senderProfileImage=default image uri)
-        , MessageResponseDto(id=120, content=보낸메시지0-익명,안읽음, anonymous=true, senderNickname=익명, senderProfileImage=기본 이미지)
+        , MessageResponseDto(id=120, content=보낸메시지0-익명,안읽음, anonymous=true, senderNickname=익명, senderProfileImage="")
         , MessageResponseDto(id=122, content=보낸메시지2-익명아님,읽음,즐겨찾기, anonymous=false, senderNickname=닉네임, senderProfileImage=default image uri)]
          */
     }
@@ -242,7 +242,7 @@ public class AcceptanceTest {
 
         SendUserDto sender = userService.findBySenderId(message.getSenderId());
         assertThat(sender.getId()).isEqualTo(-1L);
-        assertThat(sender.getUserImage()).isEqualTo("기본이미지");
+        assertThat(sender.getUserImage()).isEqualTo("");
         assertThat(sender.getNickname()).isEqualTo("익명");
     }
 

--- a/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
@@ -242,7 +242,7 @@ public class AcceptanceTest {
 
         SendUserDto sender = userService.findBySenderId(message.getSenderId());
         assertThat(sender.getId()).isEqualTo(-1L);
-        assertThat(sender.getUserImage()).isEqualTo("");
+        assertThat(sender.getUserImage()).isEqualTo("1");
         assertThat(sender.getNickname()).isEqualTo("익명");
     }
 

--- a/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
@@ -282,7 +282,7 @@ public class ForestControllerTest extends ControllerTest {
     @DisplayName("나무 삭제 - 기본폴더는 삭제할 수 없다")
     @Test
     void deleteTreeTest() throws Exception {
-        willThrow(new BetreeException(ErrorCode.TREE_DEFAULT_DELETE_ERROR))
+        willThrow(new BetreeException(ErrorCode.TREE_DEFAULT_ERROR))
                 .given(folderService).deleteTree(eq(1L), eq(18L));
 
         mockMvc.perform(delete("/api/forest/18")
@@ -292,6 +292,6 @@ public class ForestControllerTest extends ControllerTest {
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("T004"));
+                .andExpect(jsonPath("$.code").value("T002"));
     }
 }

--- a/src/test/java/com/yapp/betree/domain/EntityTest.java
+++ b/src/test/java/com/yapp/betree/domain/EntityTest.java
@@ -28,7 +28,7 @@ public class EntityTest {
         User user = User.builder()
                 .nickname("user")
                 .email("user@user.com")
-                .url("testUrl")
+                .url("")
                 .lastAccessTime(LocalDateTime.now())
                 .userImage("123")
                 .build();

--- a/src/test/java/com/yapp/betree/domain/UserTest.java
+++ b/src/test/java/com/yapp/betree/domain/UserTest.java
@@ -14,7 +14,7 @@ public class UserTest {
             .oauthId(1L)
             .nickname("닉네임")
             .email("email@email.com")
-            .userImage("default image uri")
+            .userImage("1")
             .lastAccessTime(LocalDateTime.now())
             .url(BetreeUtils.makeUserAccessUrl(1L))
             .build();
@@ -23,13 +23,13 @@ public class UserTest {
             .oauthId(1L)
             .nickname("닉네임")
             .email("email@email.com")
-            .userImage("default image uri")
+            .userImage("1")
             .lastAccessTime(LocalDateTime.now())
             .url(BetreeUtils.makeUserAccessUrl(1L))
             .build();
     public static final SendUserDto TEST_SAVE_USER_DTO = SendUserDto.builder()
             .id(1L)
             .nickname("닉네임")
-            .userImage("default image uri")
+            .userImage("1")
             .build();
 }

--- a/src/test/java/com/yapp/betree/repository/MessageRepositoryTest.java
+++ b/src/test/java/com/yapp/betree/repository/MessageRepositoryTest.java
@@ -106,10 +106,13 @@ public class MessageRepositoryTest {
     @DisplayName("이전 , 다음 메세지 조회 테스트")
     @Test
     void findPrevNextMessageTest() {
-        User user = UserTest.TEST_SAVE_USER;
+        User user = UserTest.TEST_USER;
         user.addFolder(FolderTest.TEST_DEFAULT_TREE);
+        user.addFolder(FolderTest.TEST_APPLE_TREE);
         userRepository.save(user);
 
+        Folder folder = folderRepository.findByUserIdAndFruit(user.getId(), FruitType.DEFAULT);
+        Folder appleFolder = folderRepository.findByUserIdAndFruit(user.getId(), FruitType.APPLE);
         Message message1 = Message.builder()
                 .content("안녕1")
                 .senderId(user.getId())
@@ -118,8 +121,20 @@ public class MessageRepositoryTest {
                 .favorite(true)
                 .opening(false)
                 .user(user)
+                .folder(folder)
                 .build();
         messageRepository.save(message1);
+        Message messageApple1 = Message.builder()
+                .content("안녕1")
+                .senderId(user.getId())
+                .anonymous(false)
+                .alreadyRead(true)
+                .favorite(true)
+                .opening(false)
+                .user(user)
+                .folder(appleFolder)
+                .build();
+        messageRepository.save(messageApple1);
 
         Message message2 = Message.builder()
                 .content("안녕2")
@@ -129,11 +144,25 @@ public class MessageRepositoryTest {
                 .favorite(false)
                 .opening(false)
                 .user(user)
+                .folder(folder)
                 .build();
         messageRepository.save(message2);
+        Message messageApple2 = Message.builder()
+                .content("안녕1")
+                .senderId(user.getId())
+                .anonymous(false)
+                .alreadyRead(true)
+                .favorite(true)
+                .opening(false)
+                .user(user)
+                .folder(appleFolder)
+                .build();
+        messageRepository.save(messageApple2);
 
-        Optional<Message> prevMessage = messageRepository.findTop1ByUserIdAndIdLessThanOrderByIdDesc(user.getId(), message1.getId());
-        Optional<Message> nextMessage = messageRepository.findTop1ByUserIdAndIdGreaterThan(user.getId(), message1.getId());
+        List<Message> all = messageRepository.findAll();
+        assertThat(all).hasSize(4);
+        Optional<Message> prevMessage = messageRepository.findTop1ByUserIdAndFolderIdAndIdLessThanOrderByIdDesc(user.getId(), message1.getId(), folder.getId());
+        Optional<Message> nextMessage = messageRepository.findTop1ByUserIdAndFolderIdAndIdGreaterThan(user.getId(), message1.getId(), folder.getId());
 
         assertThatThrownBy(prevMessage::get).isInstanceOf(NoSuchElementException.class);
         assertThat(nextMessage.get().getId()).isEqualTo(message2.getId());

--- a/src/test/java/com/yapp/betree/service/FolderServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/FolderServiceTest.java
@@ -13,6 +13,7 @@ import com.yapp.betree.exception.BetreeException;
 import com.yapp.betree.exception.ErrorCode;
 import com.yapp.betree.repository.FolderRepository;
 import com.yapp.betree.repository.MessageRepository;
+import com.yapp.betree.util.BetreeUtils;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -117,7 +118,7 @@ public class FolderServiceTest {
         // then
         assertThat(message.isAnonymous()).isTrue();
         assertThat(message.getSenderNickname()).isEqualTo("익명");
-        assertThat(message.getSenderProfileImage()).isEqualTo("");
+        assertThat(message.getSenderProfileImage()).isEqualTo(BetreeUtils.getImageUrl("-1"));
         assertThat(trees.getId()).isEqualTo(TEST_SAVE_DEFAULT_TREE.getId());
         assertThat(trees.getName()).isEqualTo(TEST_SAVE_DEFAULT_TREE.getName());
     }
@@ -156,7 +157,7 @@ public class FolderServiceTest {
         // then
         assertThat(message.isAnonymous()).isTrue();
         assertThat(message.getSenderNickname()).isEqualTo("익명");
-        assertThat(message.getSenderProfileImage()).isEqualTo("");
+        assertThat(message.getSenderProfileImage()).isEqualTo(BetreeUtils.getImageUrl("-1"));
         assertThat(trees.getId()).isEqualTo(TEST_SAVE_DEFAULT_TREE.getId());
         assertThat(trees.getName()).isEqualTo(TEST_SAVE_DEFAULT_TREE.getName());
     }

--- a/src/test/java/com/yapp/betree/service/FolderServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/FolderServiceTest.java
@@ -84,7 +84,8 @@ public class FolderServiceTest {
 
         assertThatThrownBy(() -> folderService.userDetailTree(USER_ID, TREE_ID))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("나무가 존재하지 않습니다.");
+                .hasMessageContaining("나무가 존재하지 않습니다.")
+                .extracting("code").isEqualTo(ErrorCode.TREE_NOT_FOUND);
     }
 
     @Test
@@ -94,7 +95,8 @@ public class FolderServiceTest {
 
         assertThatThrownBy(() -> folderService.userDetailTree(2L, TREE_ID))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("잘못된 접근입니다.");
+                .hasMessageContaining("잘못된 접근입니다.")
+                .extracting("code").isEqualTo(ErrorCode.USER_FORBIDDEN);
     }
 
     @Test
@@ -133,7 +135,8 @@ public class FolderServiceTest {
         // then
         assertThatThrownBy(() -> folderService.userDetailTree(USER_ID, TREE_ID))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("회원을 찾을 수 없습니다.");
+                .hasMessageContaining("회원을 찾을 수 없습니다.")
+                .extracting("code").isEqualTo(ErrorCode.USER_NOT_FOUND);
     }
 
     @Test
@@ -187,7 +190,8 @@ public class FolderServiceTest {
 
         assertThatThrownBy(() -> folderService.createTree(userId, null))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("회원을 찾을 수 없습니다.");
+                .hasMessageContaining("회원을 찾을 수 없습니다.")
+                .extracting("code").isEqualTo(ErrorCode.USER_NOT_FOUND);
     }
 
     @Test
@@ -204,7 +208,8 @@ public class FolderServiceTest {
 
         assertThatThrownBy(() -> folderService.createTree(userId, apple_tree))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("나무는 최대 4개까지 추가 가능합니다.");
+                .hasMessageContaining("나무는 최대 4개까지 추가 가능합니다.")
+                .extracting("code").isEqualTo(ErrorCode.TREE_COUNT_ERROR);
     }
 
     @Test
@@ -238,7 +243,8 @@ public class FolderServiceTest {
 
         assertThatThrownBy(() -> folderService.updateTree(userId, null, null))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("회원을 찾을 수 없습니다.");
+                .hasMessageContaining("회원을 찾을 수 없습니다.")
+                .extracting("code").isEqualTo(ErrorCode.USER_NOT_FOUND);
     }
 
     @Test
@@ -252,7 +258,8 @@ public class FolderServiceTest {
         given(folderRepository.findById(treeId)).willReturn(Optional.empty());
         assertThatThrownBy(() -> folderService.updateTree(userId, treeId, null))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("나무가 존재하지 않습니다.");
+                .hasMessageContaining("나무가 존재하지 않습니다.")
+                .extracting("code").isEqualTo(ErrorCode.TREE_NOT_FOUND);
     }
 
     @Test
@@ -269,7 +276,8 @@ public class FolderServiceTest {
 
         assertThatThrownBy(() -> folderService.updateTree(user.getId(), treeId, null))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("잘못된 접근입니다.: 유저와 나무의 주인이 일치하지 않습니다.");
+                .hasMessageContaining("잘못된 접근입니다.: 유저와 나무의 주인이 일치하지 않습니다.")
+                .extracting("code").isEqualTo(ErrorCode.USER_FORBIDDEN);
     }
 
     @Test

--- a/src/test/java/com/yapp/betree/service/FolderServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/FolderServiceTest.java
@@ -115,7 +115,7 @@ public class FolderServiceTest {
         // then
         assertThat(message.isAnonymous()).isTrue();
         assertThat(message.getSenderNickname()).isEqualTo("익명");
-        assertThat(message.getSenderProfileImage()).isEqualTo("기본 이미지");
+        assertThat(message.getSenderProfileImage()).isEqualTo("");
         assertThat(trees.getId()).isEqualTo(TEST_SAVE_DEFAULT_TREE.getId());
         assertThat(trees.getName()).isEqualTo(TEST_SAVE_DEFAULT_TREE.getName());
     }
@@ -153,7 +153,7 @@ public class FolderServiceTest {
         // then
         assertThat(message.isAnonymous()).isTrue();
         assertThat(message.getSenderNickname()).isEqualTo("익명");
-        assertThat(message.getSenderProfileImage()).isEqualTo("기본 이미지");
+        assertThat(message.getSenderProfileImage()).isEqualTo("");
         assertThat(trees.getId()).isEqualTo(TEST_SAVE_DEFAULT_TREE.getId());
         assertThat(trees.getName()).isEqualTo(TEST_SAVE_DEFAULT_TREE.getName());
     }

--- a/src/test/java/com/yapp/betree/service/FolderServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/FolderServiceTest.java
@@ -52,7 +52,7 @@ public class FolderServiceTest {
     private FolderService folderService;
 
     @Test
-    @DisplayName("유저 나무숲 조회 - 유저 id로 나무숲을 전체 조회한다.")
+    @DisplayName("유저 나무숲 조회 - 유저 id로 나무숲을 전체 조회한다. 기본나무는 포함되지 않는다.")
     void userForestTest() {
         // given
         given(folderRepository.findAllByUserId(USER_ID)).willReturn(Lists.newArrayList(TEST_SAVE_APPLE_TREE, TEST_SAVE_DEFAULT_TREE));
@@ -61,7 +61,7 @@ public class FolderServiceTest {
         List<TreeResponseDto> treeResponseDtos = folderService.userForest(USER_ID, USER_ID);
 
         // then
-        assertThat(treeResponseDtos).contains(TreeResponseDto.of(TEST_SAVE_APPLE_TREE), TreeResponseDto.of(TEST_SAVE_DEFAULT_TREE));
+        assertThat(treeResponseDtos).contains(TreeResponseDto.of(TEST_SAVE_APPLE_TREE));
     }
 
     @Test
@@ -285,7 +285,8 @@ public class FolderServiceTest {
         TreeRequestDto treeRequestDto = TreeRequestDto.builder().name("변경 이름").fruitType(FruitType.APPLE).build();
         assertThatThrownBy(() -> folderService.updateTree(userId, treeId, treeRequestDto))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("기본 나무를 생성,변경 할 수 없습니다.");
+                .hasMessageContaining("기본 나무를 생성,변경 할 수 없습니다.")
+                .extracting("code").isEqualTo(ErrorCode.TREE_DEFAULT_ERROR);
     }
 
     @Test
@@ -300,6 +301,7 @@ public class FolderServiceTest {
 
         assertThatThrownBy(() -> folderService.deleteTree(userId, treeId))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("기본 나무를 삭제할 수 없습니다.");
+                .hasMessageContaining("기본 나무를 생성,변경 할 수 없습니다.")
+                .extracting("code").isEqualTo(ErrorCode.TREE_DEFAULT_ERROR);
     }
 }

--- a/src/test/java/com/yapp/betree/service/JwtTokenTest.java
+++ b/src/test/java/com/yapp/betree/service/JwtTokenTest.java
@@ -3,6 +3,7 @@ package com.yapp.betree.service;
 import com.yapp.betree.dto.LoginUserDto;
 import com.yapp.betree.dto.oauth.JwtTokenDto;
 import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.exception.ErrorCode;
 import com.yapp.betree.service.oauth.JwtTokenProvider;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
@@ -63,11 +64,13 @@ public class JwtTokenTest {
 
         assertThatThrownBy(() -> jwtTokenProvider.parseToken(tokenDto.getAccessToken()))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("만료");
+                .hasMessageContaining("만료")
+                .extracting("code").isEqualTo(ErrorCode.USER_TOKEN_EXPIRED);
 
         assertThatThrownBy(() -> jwtTokenProvider.parseToken(tokenDto.getRefreshToken()))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("만료");
+                .hasMessageContaining("만료")
+                .extracting("code").isEqualTo(ErrorCode.USER_TOKEN_EXPIRED);
     }
 
     @Test
@@ -82,6 +85,7 @@ public class JwtTokenTest {
         // then
         assertThatThrownBy(() -> jwtTokenProvider.parseToken(tokenDto.getAccessToken()))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("토큰 파싱에 실패했습니다.");
+                .hasMessageContaining("토큰 파싱에 실패했습니다.")
+                .extracting("code").isEqualTo(ErrorCode.USER_TOKEN_ERROR);
     }
 }

--- a/src/test/java/com/yapp/betree/service/KakaoApiServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/KakaoApiServiceTest.java
@@ -7,6 +7,7 @@ import com.yapp.betree.dto.oauth.KakaoTokenInfoDto;
 import com.yapp.betree.dto.oauth.KakaoUserInfoDto;
 import com.yapp.betree.dto.oauth.OAuthUserInfoDto;
 import com.yapp.betree.exception.BetreeException;
+import com.yapp.betree.exception.ErrorCode;
 import com.yapp.betree.service.oauth.KakaoApiService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -78,7 +79,8 @@ public class KakaoApiServiceTest {
 
         assertThatThrownBy(() -> kakaoApiService.getOauthId("accessToken"))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("accessToken");
+                .hasMessageContaining("accessToken")
+                .extracting("code").isEqualTo(ErrorCode.OAUTH_ACCESS_TOKEN_EXPIRED);
     }
 
     @Test
@@ -110,6 +112,7 @@ public class KakaoApiServiceTest {
 
         assertThatThrownBy(() -> kakaoApiService.getUserInfo("accessToken"))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("email is null");
+                .hasMessageContaining("email is null")
+                .extracting("code").isEqualTo(ErrorCode.OAUTH_INVALID_USERINFO);
     }
 }

--- a/src/test/java/com/yapp/betree/service/MessageServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/MessageServiceTest.java
@@ -159,6 +159,7 @@ public class MessageServiceTest {
     @DisplayName("메세지 읽음 설정 - 존재하지 않는 messageId 입력시 예외 발생")
     void readMessageNotFound() {
 
+        given(userRepository.findById(TEST_SAVE_USER.getId())).willReturn(Optional.of(TEST_SAVE_USER));
         given(messageRepository.findByIdAndUserIdAndDelByReceiver(10L, TEST_SAVE_USER.getId(), false)).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
 
         assertThatThrownBy(() -> messageService.updateReadMessage(TEST_SAVE_USER.getId(), 10L))

--- a/src/test/java/com/yapp/betree/service/MessageServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/MessageServiceTest.java
@@ -85,7 +85,8 @@ public class MessageServiceTest {
 
         assertThatThrownBy(() -> messageService.createMessage(1L, requestDto))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("나무가 존재하지 않습니다.");
+                .hasMessageContaining("나무가 존재하지 않습니다.")
+                .extracting("code").isEqualTo(ErrorCode.TREE_NOT_FOUND);
     }
 
     @Test
@@ -96,7 +97,8 @@ public class MessageServiceTest {
 
         assertThatThrownBy(() -> messageService.updateMessageOpening(TEST_SAVE_USER.getId(), messageIds))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("Invalid input value");
+                .hasMessageContaining("Invalid input value")
+                .extracting("code").isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
     }
 
     @Test
@@ -109,7 +111,8 @@ public class MessageServiceTest {
 
         assertThatThrownBy(() -> messageService.deleteMessages(TEST_SAVE_USER.getId(), messageIds))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("메세지가 존재하지 않습니다.");
+                .hasMessageContaining("메세지가 존재하지 않습니다.")
+                .extracting("code").isEqualTo(ErrorCode.MESSAGE_NOT_FOUND);
     }
 
     @Test
@@ -121,7 +124,8 @@ public class MessageServiceTest {
 
         assertThatThrownBy(() -> messageService.moveMessageFolder(TEST_SAVE_USER.getId(), messageIds, 10L))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("나무가 존재하지 않습니다.");
+                .hasMessageContaining("나무가 존재하지 않습니다.")
+                .extracting("code").isEqualTo(ErrorCode.TREE_NOT_FOUND);
     }
 
     @Test
@@ -132,7 +136,8 @@ public class MessageServiceTest {
 
         assertThatThrownBy(() -> messageService.updateFavoriteMessage(TEST_SAVE_USER.getId(), 10L))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("메세지가 존재하지 않습니다.");
+                .hasMessageContaining("메세지가 존재하지 않습니다.")
+                .extracting("code").isEqualTo(ErrorCode.MESSAGE_NOT_FOUND);
     }
 
     @Test
@@ -158,7 +163,8 @@ public class MessageServiceTest {
 
         assertThatThrownBy(() -> messageService.updateReadMessage(TEST_SAVE_USER.getId(), 10L))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("메세지가 존재하지 않습니다.");
+                .hasMessageContaining("메세지가 존재하지 않습니다.")
+                .extracting("code").isEqualTo(ErrorCode.MESSAGE_NOT_FOUND);
     }
 
     @Test
@@ -169,6 +175,7 @@ public class MessageServiceTest {
 
         assertThatThrownBy(() -> messageService.getMessageDetail(TEST_SAVE_USER.getId(), 10L))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("메세지가 존재하지 않습니다.");
+                .hasMessageContaining("메세지가 존재하지 않습니다.")
+                .extracting("code").isEqualTo(ErrorCode.MESSAGE_NOT_FOUND);
     }
 }

--- a/src/test/java/com/yapp/betree/service/UserServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/UserServiceTest.java
@@ -96,7 +96,8 @@ public class UserServiceTest {
 
         assertThatThrownBy(() -> userService.deleteRefreshToken(userId))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("이미 로그아웃된 유저입니다.");
+                .hasMessageContaining("이미 로그아웃된 유저입니다.")
+                .extracting("code").isEqualTo(ErrorCode.USER_ALREADY_LOGOUT_TOKEN);
                 
     }
     @Test
@@ -108,7 +109,8 @@ public class UserServiceTest {
         // then
         assertThatThrownBy(() -> userService.getUser(TEST_SAVE_USER.getId()))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("회원을 찾을 수 없습니다.");
+                .hasMessageContaining("회원을 찾을 수 없습니다.")
+                .extracting("code").isEqualTo(ErrorCode.USER_NOT_FOUND);
     }
 
     @Test
@@ -120,6 +122,7 @@ public class UserServiceTest {
         // then
         assertThatThrownBy(() -> userService.updateUserNickname(TEST_SAVE_USER.getId(), "nickname"))
                 .isInstanceOf(BetreeException.class)
-                .hasMessageContaining("회원을 찾을 수 없습니다.");
+                .hasMessageContaining("회원을 찾을 수 없습니다.")
+                .extracting("code").isEqualTo(ErrorCode.USER_NOT_FOUND);
     }
 }

--- a/src/test/java/com/yapp/betree/util/BetreeUtilsTest.java
+++ b/src/test/java/com/yapp/betree/util/BetreeUtilsTest.java
@@ -19,7 +19,7 @@ public class BetreeUtilsTest {
     @Test
     @DisplayName("1~4 랜덤숫자 생성 테스트")
     void makeUesrImageTest() {
-        String randomNumber = BetreeUtils.makeUserImage();
+        String randomNumber = BetreeUtils.makeUserImageNumber();
         assertThat(randomNumber).isGreaterThanOrEqualTo("1");
         assertThat(randomNumber).isLessThanOrEqualTo("4");
     }

--- a/src/test/java/com/yapp/betree/util/BetreeUtilsTest.java
+++ b/src/test/java/com/yapp/betree/util/BetreeUtilsTest.java
@@ -4,6 +4,8 @@ import com.yapp.betree.dto.response.MessageResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @DisplayName("유틸 클래스 테스트")
 public class BetreeUtilsTest {
 
@@ -12,5 +14,13 @@ public class BetreeUtilsTest {
     void betreeMessageTest() {
         MessageResponseDto betreeMessage = BetreeUtils.getBetreeMessage(1L);
         System.out.println(betreeMessage);
+    }
+
+    @Test
+    @DisplayName("1~4 랜덤숫자 생성 테스트")
+    void makeUesrImageTest() {
+        String randomNumber = BetreeUtils.makeUserImage();
+        assertThat(randomNumber).isGreaterThanOrEqualTo("1");
+        assertThat(randomNumber).isLessThanOrEqualTo("4");
     }
 }


### PR DESCRIPTION
## 이슈
- #77 

## 작업 내용
- [x] 회원가입시 유저 프로필 이미지 생성로직 변경 -> 1~4중 하나 생성되도록
  - 익명일 경우 흑백이미지, 비트리 제공 메시지의 경우 비트리 로고로 반환되는 처리 필요 
  - 백엔드에서 처리하기로해서 백엔드 resource 위치에 이미지 넣어두고 가져오는거로 해야될듯
- [x] 유저 url `""`로 반환 -> 프론트엔드에서 처리
- [x] 유저 나무숲 조회 기본나무는 보여지지않도록 수정
- [x] 메시지 읽음여부 변경할 때 음수값의 메시지도 읽음처리되도록 수정
- [x] 메시지함에서 메시지 prevId, nextId 가 같은 폴더가 아닌 메시지로 보여지는 오류 수정

## 기타 사항
- 테스트코드 `assertThatThrownBy`사용할 때 `extracting`으로 code를 추출할 수 있어서, `hasMessageXX`말고 `extracting`으로 테스트하면 예외메시지가 혹시 변경되더라도 테스트코드에서 바꾸지 않아도 될 것 같아욥! 참고해주세요 
- 나무 수정,편집,삭제하는 메서드에서 기본나무에 대한 접근을 할 경우 예외 날려주는거를 `validateFolder`쪽에 하나로 이동시켰습니다! 

## 체크리스트
- [x] 테스트 성공 확인