### PR TITLE
feat: 회원가입시 비트리 기본메시지 생성 추가

### DIFF
--- a/src/main/java/com/yapp/betree/domain/Message.java
+++ b/src/main/java/com/yapp/betree/domain/Message.java
@@ -55,6 +55,24 @@ public class Message extends BaseTimeEntity {
         this.folder = folder;
     }
 
+    public static Message generateWelcomeMessage(User user, Folder folder) {
+        return Message.builder()
+                .content("STEP 1. \"물 주기\"를 통해 칭찬 메시지를 작성하세요!\n" +
+                        "STEP 2. 다양한 열매 나무를 심고 칭찬 메시지를 분류하세요!\n" +
+                        "STEP 3. 열매 맺을 메시지를 선택해 나만의 나무숲을 가꾸세요!\n" +
+                        "STEP 4. URL을 통해 나만의 나무숲을 공유하고 나무를 무럭무럭 키우세요!")
+                .senderId(-999L)
+                .anonymous(false)
+                .alreadyRead(false)
+                .favorite(false)
+                .opening(true)
+                .delBySender(false)
+                .delByReceiver(false)
+                .user(user)
+                .folder(folder)
+                .build();
+    }
+
     /**
      * 읽음 여부 상태 변경 메서드
      */

--- a/src/main/java/com/yapp/betree/dto/SendUserDto.java
+++ b/src/main/java/com/yapp/betree/dto/SendUserDto.java
@@ -39,4 +39,11 @@ public class SendUserDto {
                 .userImage(BetreeUtils.getImageUrl("-1"))
                 .build();
     }
+    public static SendUserDto ofBetree() {
+        return SendUserDto.builder()
+                .id(-999L)
+                .nickname("Betree")
+                .userImage(BetreeUtils.getImageUrl("0"))
+                .build();
+    }
 }

--- a/src/main/java/com/yapp/betree/service/LoginService.java
+++ b/src/main/java/com/yapp/betree/service/LoginService.java
@@ -26,6 +26,7 @@ public class LoginService {
     private final KakaoApiService kakaoApiService;
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final MessageService messageService;
 
     @Transactional
     public JwtTokenDto createToken(String accessToken) {
@@ -39,6 +40,7 @@ public class LoginService {
             OAuthUserInfoDto oAuthUserInfoDto = kakaoApiService.getUserInfo(accessToken);
             // 2-2. DB에 유저 등록(회원가입)하며 로그인 유저 생성
             loginUser = Optional.of(userService.save(oAuthUserInfoDto.generateSignUpUser()));
+            messageService.sendWelcomeMessage(loginUser.get());
         }
 
         JwtTokenDto token = jwtTokenProvider.createToken(LoginUserDto.of(loginUser.get()));

--- a/src/main/java/com/yapp/betree/service/UserService.java
+++ b/src/main/java/com/yapp/betree/service/UserService.java
@@ -42,6 +42,9 @@ public class UserService {
         if (userId == -1L) {
             return SendUserDto.ofNoLogin();
         }
+        if (userId == -999L) {
+            return SendUserDto.ofBetree();
+        }
         User user = userRepository.findById(userId).orElseThrow(() -> new BetreeException(USER_NOT_FOUND, "senderId = " + userId));
         return SendUserDto.of(user);
     }

--- a/src/main/java/com/yapp/betree/util/BetreeUtils.java
+++ b/src/main/java/com/yapp/betree/util/BetreeUtils.java
@@ -55,6 +55,7 @@ public class BetreeUtils {
 
         Message message = Message.builder()
                 .id(key)
+                .senderId(-999L)
                 .content(value)
                 .anonymous(false)
                 .alreadyRead(false)

--- a/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/AcceptanceTest.java
@@ -115,6 +115,11 @@ public class AcceptanceTest {
         assertThat(folders.get(0).getFruit()).isEqualTo(FruitType.DEFAULT);
 
         assertThat(user.getFolders().get(0).getId()).isEqualTo(folders.get(0).getId());
+
+        List<Message> all = messageRepository.findAll();
+        Message messages = all.get(0);
+        assertThat(messages.getSenderId()).isEqualTo(-999L);
+        assertThat(messages.getContent()).contains("STEP");
     }
 
     @Test

--- a/src/test/java/com/yapp/betree/service/MessageServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/MessageServiceTest.java
@@ -2,6 +2,7 @@ package com.yapp.betree.service;
 
 import com.yapp.betree.domain.FruitType;
 import com.yapp.betree.domain.Message;
+import com.yapp.betree.dto.SendUserDto;
 import com.yapp.betree.dto.request.MessageRequestDto;
 import com.yapp.betree.dto.response.MessagePageResponseDto;
 import com.yapp.betree.exception.BetreeException;
@@ -37,6 +38,8 @@ public class MessageServiceTest {
     @Mock
     private UserRepository userRepository;
     @Mock
+    private UserService userService;
+    @Mock
     private FolderRepository folderRepository;
     @InjectMocks
     private MessageService messageService;
@@ -53,6 +56,7 @@ public class MessageServiceTest {
 
             SliceImpl<Message> messages = new SliceImpl<>(Collections.singletonList(TEST_SAVE_ANONYMOUS_MESSAGE));
             given(messageRepository.findByUserIdAndFolderIdAndDelByReceiver(TEST_SAVE_USER.getId(), TEST_SAVE_DEFAULT_TREE.getId(), false, pageable)).willReturn(messages);
+            given(userService.findBySenderId(TEST_SAVE_USER.getId())).willReturn(SendUserDto.of(TEST_SAVE_USER));
             given(folderRepository.findByUserIdAndFruit(TEST_SAVE_USER.getId(), FruitType.DEFAULT)).willReturn(TEST_SAVE_DEFAULT_TREE);
 
             MessagePageResponseDto messageList = messageService.getMessageList(TEST_SAVE_USER.getId(), pageable, null);
@@ -67,7 +71,7 @@ public class MessageServiceTest {
 
             SliceImpl<Message> messages = new SliceImpl<>(Collections.singletonList(TEST_SAVE_ANONYMOUS_MESSAGE));
             given(messageRepository.findByUserIdAndFolderIdAndDelByReceiver(TEST_SAVE_USER.getId(), TEST_SAVE_DEFAULT_TREE.getId(), false, pageable)).willReturn(messages);
-
+            given(userService.findBySenderId(TEST_SAVE_USER.getId())).willReturn(SendUserDto.of(TEST_SAVE_USER));
             MessagePageResponseDto messageList = messageService.getMessageList(TEST_SAVE_USER.getId(), pageable, TEST_SAVE_DEFAULT_TREE.getId());
 
             assertThat(messageList.getResponseDto().size()).isEqualTo(1);


### PR DESCRIPTION
## 이슈
- #62 

## 작업 내용
- 회원가입시에 기본폴더로 기본메시지 생성
- -999L : betree 

## 기타 사항
- 테스트할때 디버깅해보면 기본메시지 user와 받는user가 다르게되는데 실제로돌리면 제대로 들어가긴함

## 체크리스트
- [x] 테스트성공