### PR TITLE
fix: 유저나무숲 응답값에 공개여부 추가

### DIFF
--- a/src/main/java/com/yapp/betree/dto/response/TreeResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/TreeResponseDto.java
@@ -16,12 +16,14 @@ public class TreeResponseDto {
     private Long id;
     private String name;
     private FruitType fruit;
+    private boolean opening;
 
     @Builder
-    public TreeResponseDto(Long id, String name, FruitType fruit) {
+    public TreeResponseDto(Long id, String name, FruitType fruit, boolean opening) {
         this.id = id;
         this.name = name;
         this.fruit = fruit;
+        this.opening = opening;
     }
 
     public static TreeResponseDto of(Folder folder) {
@@ -29,12 +31,13 @@ public class TreeResponseDto {
                 .id(folder.getId())
                 .name(folder.getName())
                 .fruit(folder.getFruit())
+                .opening(folder.isOpening())
                 .build();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name);
+        return Objects.hash(id, name, fruit, opening);
     }
 
     @Override
@@ -47,6 +50,9 @@ public class TreeResponseDto {
             return false;
         }
         if (this.fruit != objDto.getFruit()) {
+            return false;
+        }
+        if (this.opening != objDto.isOpening()) {
             return false;
         }
         return true;

--- a/src/test/java/com/yapp/betree/domain/FolderTest.java
+++ b/src/test/java/com/yapp/betree/domain/FolderTest.java
@@ -63,6 +63,7 @@ public class FolderTest {
                 .id(TEST_SAVE_APPLE_TREE.getId())
                 .name(TEST_SAVE_APPLE_TREE.getName())
                 .fruit(TEST_SAVE_APPLE_TREE.getFruit())
+                .opening(TEST_SAVE_APPLE_TREE.isOpening())
                 .build();
         assertThat(of).isEqualTo(build);
         assertThat(of.hashCode()).isEqualTo(build.hashCode());


### PR DESCRIPTION
## 이슈

## 작업 내용
- 유저 나무숲 조회 메시지함에서 같이 쓸텐데 공개여부 있어야 사용하기 편할것같아서 Opening필드 추가했습니다

## 기타 사항
- 내용을 적어주세요.

## 체크리스트
- [ ] example