### PR TITLE
bug: 나무 상세 조회시 비공개폴더는 못보도록 예외처리

### DIFF
--- a/src/main/java/com/yapp/betree/controller/ForestController.java
+++ b/src/main/java/com/yapp/betree/controller/ForestController.java
@@ -77,14 +77,15 @@ public class ForestController {
     })
     @GetMapping("/api/forest/{treeId}")
     public ResponseEntity<TreeFullResponseDto> userDetailTree(
+            @ApiIgnore @LoginUser LoginUserDto loginUser,
             @RequestParam Long userId,
             @PathVariable Long treeId) {
-        log.info("[나무숲] 유저 상세 나무 조회 userId: {}, treeId: {}", userId, treeId);
+        log.info("[나무숲] 유저 상세 나무 조회 userId: {}, treeId: {}, 로그인 유저 정보 : {}", userId, treeId, loginUser);
 
         if (!userService.isExist(userId)) {
             throw new BetreeException(ErrorCode.USER_NOT_FOUND, "userId = " + userId);
         }
-        return ResponseEntity.ok(folderService.userDetailTree(userId, treeId));
+        return ResponseEntity.ok(folderService.userDetailTree(userId, treeId, loginUser.getId()));
     }
 
     /**

--- a/src/main/java/com/yapp/betree/interceptor/TokenInterceptor.java
+++ b/src/main/java/com/yapp/betree/interceptor/TokenInterceptor.java
@@ -88,14 +88,9 @@ public class TokenInterceptor implements HandlerInterceptor {
 
     private boolean isPassRequest(HttpServletRequest request) {
 
-        // 나무숲 상세조회
-        if (request.getRequestURI().startsWith("/api/forest/") && request.getMethod().equals(String.valueOf(HttpMethod.GET))) {
-            return true;
-        }
-
-        // 물주기 & 나무 숲 조회
+        // 나무숲 상세조회 & 물주기 & 나무 숲 조회
         if (request.getRequestURI().equals("/api/messages") && request.getMethod().equals(String.valueOf(HttpMethod.POST)) ||
-                request.getRequestURI().equals("/api/forest") && request.getMethod().equals(String.valueOf(HttpMethod.GET))) {
+                request.getRequestURI().startsWith("/api/forest") && request.getMethod().equals(String.valueOf(HttpMethod.GET))) {
 
             Optional<String> authHeader = Optional.ofNullable(request.getHeader("Authorization"));
 

--- a/src/main/java/com/yapp/betree/service/FolderService.java
+++ b/src/main/java/com/yapp/betree/service/FolderService.java
@@ -65,12 +65,16 @@ public class FolderService {
      * @param treeId
      * @return TreeFullResponseDto
      */
-    public TreeFullResponseDto userDetailTree(Long userId, Long treeId) {
+    public TreeFullResponseDto userDetailTree(Long userId, Long treeId, Long loginUserId) {
 
         Folder folder = folderRepository.findById(treeId).orElseThrow(() -> new BetreeException(ErrorCode.TREE_NOT_FOUND, "treeId = " + treeId));
 
         if (folder.getUser().getId() != userId) {
             throw new BetreeException(ErrorCode.USER_FORBIDDEN, "유저와 나무의 주인이 일치하지 않습니다.");
+        }
+
+        if (!folder.isOpening() && userId != loginUserId) {
+            throw new BetreeException(ErrorCode.TREE_NOT_FOUND, "treeId = " + treeId);
         }
 
         // 이전, 다음 폴더 없을때 0L으로 처리

--- a/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
@@ -111,7 +111,7 @@ public class ForestControllerTest extends ControllerTest {
     void userDetailTreeTest() throws Exception {
         Long userId = 1L;
         given(userService.isExist(userId)).willReturn(true);
-        given(folderService.userDetailTree(userId, 1L)).willReturn(
+        given(folderService.userDetailTree(userId, 1L, userId)).willReturn(
                 TreeFullResponseDto.builder()
                         .folder(TEST_SAVE_DEFAULT_TREE)
                         .messages(Lists.newArrayList(MessageResponseDto.of(MessageTest.TEST_SAVE_MESSAGE, SendUserDto.of(TEST_SAVE_USER))))


### PR DESCRIPTION
## 이슈
- x
## 작업 내용
- 나무 상세 조회시에 비공개폴더 조회하면 조회할 수 있음
- 비로그인, 다른유저가 상세조회 요청하면 treenotfound예외 발생하도록 수정 

## 기타 사항
- 

## 체크리스트
- [x ] 테스트 성공