### PR TITLE
fix: 메시지, 나무 상세조회 버그 수정

### DIFF
--- a/src/main/java/com/yapp/betree/dto/response/MessageDetailResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessageDetailResponseDto.java
@@ -7,20 +7,23 @@ import lombok.*;
 public class MessageDetailResponseDto {
 
     private MessageBoxResponseDto responseDto;
+    private TreeResponseDto treeResponseDto;
     private Long prevId;
     private Long nextId;
 
 
     @Builder
-    public MessageDetailResponseDto(MessageBoxResponseDto responseDto, Long prevId, Long nextId) {
+    public MessageDetailResponseDto(MessageBoxResponseDto responseDto, TreeResponseDto treeResponseDto, Long prevId, Long nextId) {
         this.responseDto = responseDto;
+        this.treeResponseDto = treeResponseDto;
         this.prevId = prevId;
         this.nextId = nextId;
     }
 
-    public static MessageDetailResponseDto of(MessageBoxResponseDto responseDto, Long prevId, Long nextId) {
+    public static MessageDetailResponseDto of(MessageBoxResponseDto responseDto, TreeResponseDto treeResponseDto, Long prevId, Long nextId) {
         return MessageDetailResponseDto.builder()
                 .responseDto(responseDto)
+                .treeResponseDto(treeResponseDto)
                 .prevId(prevId)
                 .nextId(nextId)
                 .build();

--- a/src/main/java/com/yapp/betree/service/FolderService.java
+++ b/src/main/java/com/yapp/betree/service/FolderService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 
@@ -69,11 +70,11 @@ public class FolderService {
 
         Folder folder = folderRepository.findById(treeId).orElseThrow(() -> new BetreeException(ErrorCode.TREE_NOT_FOUND, "treeId = " + treeId));
 
-        if (folder.getUser().getId() != userId) {
+        if (!Objects.equals(folder.getUser().getId(), userId)) {
             throw new BetreeException(ErrorCode.USER_FORBIDDEN, "유저와 나무의 주인이 일치하지 않습니다.");
         }
 
-        if (!folder.isOpening() && userId != loginUserId) {
+        if (!folder.isOpening() && !Objects.equals(userId, loginUserId)) {
             throw new BetreeException(ErrorCode.TREE_NOT_FOUND, "treeId = " + treeId);
         }
 

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -9,6 +9,7 @@ import com.yapp.betree.dto.request.MessageRequestDto;
 import com.yapp.betree.dto.response.MessageBoxResponseDto;
 import com.yapp.betree.dto.response.MessageDetailResponseDto;
 import com.yapp.betree.dto.response.MessagePageResponseDto;
+import com.yapp.betree.dto.response.TreeResponseDto;
 import com.yapp.betree.exception.BetreeException;
 import com.yapp.betree.exception.ErrorCode;
 import com.yapp.betree.repository.FolderRepository;
@@ -240,19 +241,20 @@ public class MessageService {
 
         MessageBoxResponseDto boxResponseDto = MessageBoxResponseDto.of(message, userService.findBySenderId(message.getSenderId()));
 
-        Long folderId = message.getFolder().getId();
-        Long prevId = messageRepository.findTop1ByUserIdAndFolderIdAndIdLessThanOrderByIdDesc(userId, folderId, messageId)
+        Folder folder = message.getFolder();
+        Long prevId = messageRepository.findTop1ByUserIdAndFolderIdAndIdLessThanOrderByIdDesc(userId, folder.getId(), messageId)
                 .map(Message::getId)
                 .orElse(0L);
-        Long nextId = messageRepository.findTop1ByUserIdAndFolderIdAndIdGreaterThan(userId, folderId, messageId)
+        Long nextId = messageRepository.findTop1ByUserIdAndFolderIdAndIdGreaterThan(userId, folder.getId(), messageId)
                 .map(Message::getId)
                 .orElse(0L);
 
-        return MessageDetailResponseDto.of(boxResponseDto, prevId, nextId);
+        return MessageDetailResponseDto.of(boxResponseDto, TreeResponseDto.of(folder), prevId, nextId);
     }
 
     /**
      * 회원가입한 유저 기본메시지 생성
+     *
      * @param user
      */
     @Transactional

--- a/src/main/java/com/yapp/betree/service/UserService.java
+++ b/src/main/java/com/yapp/betree/service/UserService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.yapp.betree.exception.ErrorCode.USER_ALREADY_LOGOUT_TOKEN;
@@ -39,10 +40,10 @@ public class UserService {
 
     public SendUserDto findBySenderId(Long userId) {
         log.info("senderId로 유저 조회 : userId = {}", userId);
-        if (userId == -1L) {
+        if (Objects.equals(userId, -1L)) {
             return SendUserDto.ofNoLogin();
         }
-        if (userId == -999L) {
+        if (Objects.equals(userId, -999L)) {
             return SendUserDto.ofBetree();
         }
         User user = userRepository.findById(userId).orElseThrow(() -> new BetreeException(USER_NOT_FOUND, "senderId = " + userId));


### PR DESCRIPTION
## 이슈
- #84 
- #85 
- #83 

## 작업 내용
- tree 상세조회 404에러 고침 -> Long ==비교하는 값 128 넘어가서 false나오는 문제
- message상세조회에 tree정보도 포함하도록 수정

## 기타 사항
- 다른 Long 비교도 equals로 변경함

## 체크리스트
- [x] 테스트 