### PR TITLE
fix: profileImage 두번 처리되는 에러 수정

### DIFF
--- a/src/main/java/com/yapp/betree/dto/response/MessageBoxResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessageBoxResponseDto.java
@@ -38,14 +38,14 @@ public class MessageBoxResponseDto {
         this.opening = message.isOpening();
         this.senderNickname = senderNickname;
         this.senderProfileImage = senderProfileImage;
-        this.createdDate= message.getCreatedDate();
+        this.createdDate = message.getCreatedDate();
     }
 
     public static MessageBoxResponseDto of(Message message, SendUserDto user) {
         return MessageBoxResponseDto.builder()
                 .message(message)
                 .senderNickname(message.isAnonymous() ? "익명" : user.getNickname())
-                .senderProfileImage(BetreeUtils.getImageUrl(message.isAnonymous() ? "-1" : user.getUserImage()))
+                .senderProfileImage(message.isAnonymous() ? BetreeUtils.getImageUrl("-1") : user.getUserImage())
                 .build();
     }
 }

--- a/src/main/java/com/yapp/betree/dto/response/MessageResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/MessageResponseDto.java
@@ -37,7 +37,7 @@ public class MessageResponseDto {
         return MessageResponseDto.builder()
                 .message(message)
                 .senderNickname(message.isAnonymous() ? "익명" : user.getNickname())
-                .senderProfileImage(BetreeUtils.getImageUrl(message.isAnonymous() ? "-1" : user.getUserImage()))
+                .senderProfileImage(message.isAnonymous() ? BetreeUtils.getImageUrl("-1") : user.getUserImage())
                 .build();
     }
 


### PR DESCRIPTION
## 이슈
- profileImage 두번처리되는 에러 

## 작업 내용
- senderDto 타고오는 messageDto.of()는 BetreeUtil안불러도됨

## 기타 사항

## 체크리스트
- [x] example