### PR TITLE
fix: 삭제된 메시지가 prev,nextId로 조회되지 않도록 수정

### DIFF
--- a/src/main/java/com/yapp/betree/repository/MessageRepository.java
+++ b/src/main/java/com/yapp/betree/repository/MessageRepository.java
@@ -31,8 +31,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findAllByUserIdAndFolderIdAndDelByReceiver(Long userId, Long folderId, boolean delByReceiver);
 
     //prev
-    Optional<Message> findTop1ByUserIdAndFolderIdAndIdLessThanOrderByIdDesc(Long userId, Long folderId, Long messageId);
+    Optional<Message> findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdLessThanOrderByIdDesc(Long userId, Long folderId, boolean delByReceiver, Long messageId);
 
     //next
-    Optional<Message> findTop1ByUserIdAndFolderIdAndIdGreaterThan(Long userId, Long folderId, Long messageId);
+    Optional<Message> findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdGreaterThan(Long userId, Long folderId, boolean delByReceiver, Long messageId);
 }

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -242,10 +242,10 @@ public class MessageService {
         MessageBoxResponseDto boxResponseDto = MessageBoxResponseDto.of(message, userService.findBySenderId(message.getSenderId()));
 
         Folder folder = message.getFolder();
-        Long prevId = messageRepository.findTop1ByUserIdAndFolderIdAndIdLessThanOrderByIdDesc(userId, folder.getId(), messageId)
+        Long prevId = messageRepository.findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdLessThanOrderByIdDesc(userId, folder.getId(), false, messageId)
                 .map(Message::getId)
                 .orElse(0L);
-        Long nextId = messageRepository.findTop1ByUserIdAndFolderIdAndIdGreaterThan(userId, folder.getId(), messageId)
+        Long nextId = messageRepository.findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdGreaterThan(userId, folder.getId(), false, messageId)
                 .map(Message::getId)
                 .orElse(0L);
 

--- a/src/test/java/com/yapp/betree/repository/MessageRepositoryTest.java
+++ b/src/test/java/com/yapp/betree/repository/MessageRepositoryTest.java
@@ -162,8 +162,8 @@ public class MessageRepositoryTest {
 
         List<Message> all = messageRepository.findAll();
         assertThat(all).hasSize(4);
-        Optional<Message> prevMessage = messageRepository.findTop1ByUserIdAndFolderIdAndIdLessThanOrderByIdDesc(user.getId(), message1.getId(), folder.getId());
-        Optional<Message> nextMessage = messageRepository.findTop1ByUserIdAndFolderIdAndIdGreaterThan(user.getId(), message1.getId(), folder.getId());
+        Optional<Message> prevMessage = messageRepository.findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdLessThanOrderByIdDesc(user.getId(), message1.getId(), false, folder.getId());
+        Optional<Message> nextMessage = messageRepository.findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdGreaterThan(user.getId(), message1.getId(), false, folder.getId());
 
         assertThatThrownBy(prevMessage::get).isInstanceOf(NoSuchElementException.class);
         assertThat(nextMessage.get().getId()).isEqualTo(message2.getId());


### PR DESCRIPTION
## 이슈
- 

## 작업 내용
- 메시지 상세조회에서 삭제된 메시지가 prev, nextId로 조회되어서 repository 메서드에 delByReceiver false 인자 추가

## 기타 사항

## 체크리스트
- [x] 테스트