### PR TITLE
fix: 알림나무 비어있을 때 처리

### DIFF
--- a/src/main/java/com/yapp/betree/service/NoticeTreeService.java
+++ b/src/main/java/com/yapp/betree/service/NoticeTreeService.java
@@ -48,6 +48,7 @@ public class NoticeTreeService {
 
         List<MessageResponseDto> messages = new ArrayList<>();
         List<Long> unreadMessageIds = Arrays.stream(noticeTree.getUnreadMessages().split(","))
+                .filter(mId -> !mId.equals(""))
                 .map(Long::parseLong)
                 .collect(Collectors.toList());
 
@@ -155,6 +156,7 @@ public class NoticeTreeService {
 
         List<Long> unreadMessages = Arrays.asList(noticeTree.getUnreadMessages().split(","))
                 .stream()
+                .filter(mId -> !mId.equals(""))
                 .map(Long::parseLong)
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## 이슈
- 알림나무 비어있을 때 null or ""인데 Long parsing하려고해서 오류 
-
<img width="1253" alt="스크린샷 2022-07-21 오후 11 52 59" src="https://user-images.githubusercontent.com/37580216/180244898-e4311415-2f7d-444c-b95c-a46dd84918d7.png">
 