### PR TITLE
feat: 로컬 개발일경우 쿠키 예외처리 - 로그인 유저 이메일로 구분

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,11 @@ jobs:
         spring.datasource.url: ${{ secrets.RDS_URL }}
         spring.datasource.username: ${{ secrets.RDS_USER_NAME }}
         spring.datasource.password: ${{ secrets.RDS_PASSWORD }}
+        dev.email.js: ${{ secrets.EMAIL_JS }}
+        dev.email.sb: ${{ secrets.EMAIL_SB }}
+        dev.email.si: ${{ secrets.EMAIL_SI }}
+        dev.email.yk: ${{ secrets.EMAIL_YK }}
+        dev.email.ym: ${{ secrets.EMAIL_YM }}
 
     - name: Grant execute permission for gradlew
       run: chmod +x ./gradlew

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,11 @@ secrets:
       secret-key: B1e2t3r4e5e6S7e8c9r0e1t
       expiration-time: 600000
       refresh-expiration-time: 86400000
+
+dev:
+  email:
+    js: default
+    sb: default
+    si: default
+    yk: default
+    ym: default


### PR DESCRIPTION
## 이슈
- #97 

## 작업 내용
- fe, be 로그인 이메일 보고 해당 이메일이면 쿠키 없어도 로그인처리하도록 임시 수정 
- 로컬에서 서버에 요청 못보내는것때문에 임시 처리한거라 더 좋은 방법 있으면 수정부탁드립니다 