### PR TITLE
fix: 즐겨찾기 메세지 상세 조회 추가

### DIFF
--- a/src/main/java/com/yapp/betree/repository/MessageRepository.java
+++ b/src/main/java/com/yapp/betree/repository/MessageRepository.java
@@ -30,9 +30,17 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     // 특정 Folder, user에 해당하는 전체 메시지 조회
     List<Message> findAllByUserIdAndFolderIdAndDelByReceiver(Long userId, Long folderId, boolean delByReceiver);
 
+    /* 폴더별 메세지 상세조회시 사용 */
     //prev
     Optional<Message> findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdLessThanOrderByIdDesc(Long userId, Long folderId, boolean delByReceiver, Long messageId);
 
     //next
     Optional<Message> findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdGreaterThan(Long userId, Long folderId, boolean delByReceiver, Long messageId);
+
+    /* 즐겨찾기 메세지 상세조회시 사용 */
+    //prev
+    Optional<Message> findTop1ByUserIdAndFavoriteAndDelByReceiverAndIdLessThanOrderByIdDesc(Long userId, boolean favorite, boolean delByReceiver, Long messageId);
+
+    //next
+    Optional<Message> findTop1ByUserIdAndFavoriteAndDelByReceiverAndIdGreaterThan(Long userId, boolean favorite, boolean delByReceiver, Long messageId);
 }

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -24,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.yapp.betree.exception.ErrorCode.*;
@@ -242,12 +241,25 @@ public class MessageService {
         MessageBoxResponseDto boxResponseDto = MessageBoxResponseDto.of(message, userService.findBySenderId(message.getSenderId()));
 
         Folder folder = message.getFolder();
-        Long prevId = messageRepository.findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdLessThanOrderByIdDesc(userId, folder.getId(), false, messageId)
-                .map(Message::getId)
-                .orElse(0L);
-        Long nextId = messageRepository.findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdGreaterThan(userId, folder.getId(), false, messageId)
-                .map(Message::getId)
-                .orElse(0L);
+
+        Long prevId;
+        Long nextId;
+        // 즐겨찾기 메세지는 즐겨찾기 메세지끼리 이전, 다음 메세지 보여주기
+        if (message.isFavorite()) {
+            prevId = messageRepository.findTop1ByUserIdAndFavoriteAndDelByReceiverAndIdLessThanOrderByIdDesc(userId, true, false, message.getId())
+                    .map(Message::getId)
+                    .orElse(0L);
+            nextId = messageRepository.findTop1ByUserIdAndFavoriteAndDelByReceiverAndIdGreaterThan(userId, true, false, message.getId())
+                    .map(Message::getId)
+                    .orElse(0L);
+        } else {
+            prevId = messageRepository.findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdLessThanOrderByIdDesc(userId, folder.getId(), false, messageId)
+                    .map(Message::getId)
+                    .orElse(0L);
+            nextId = messageRepository.findTop1ByUserIdAndFolderIdAndDelByReceiverAndIdGreaterThan(userId, folder.getId(), false, messageId)
+                    .map(Message::getId)
+                    .orElse(0L);
+        }
 
         return MessageDetailResponseDto.of(boxResponseDto, TreeResponseDto.of(folder), prevId, nextId);
     }


### PR DESCRIPTION
## 이슈
- #103

## 작업 내용
- 메세지 상세조회시 즐겨찾기한 메세지일때는 이전,다음 메세지도 즐겨찾기 메세지만 나오도록 수정

## 기타 사항
- 테스트 disable처리 (단독 실행 성공)

## 체크리스트
- [ ] example