### PR TITLE
fix: 열매 맺기 - 선택한 폴더 메세지만 초기화 후 공개 여부 설정

### DIFF
--- a/src/main/java/com/yapp/betree/controller/MessageController.java
+++ b/src/main/java/com/yapp/betree/controller/MessageController.java
@@ -3,6 +3,7 @@ package com.yapp.betree.controller;
 import com.yapp.betree.annotation.LoginUser;
 import com.yapp.betree.dto.LoginUserDto;
 import com.yapp.betree.dto.request.MessageRequestDto;
+import com.yapp.betree.dto.request.OpeningRequestDto;
 import com.yapp.betree.dto.response.MessageDetailResponseDto;
 import com.yapp.betree.dto.response.MessagePageResponseDto;
 import com.yapp.betree.service.MessageService;
@@ -83,7 +84,7 @@ public class MessageController {
      * 메세지 공개 여부 설정 (열매 맺기)
      *
      * @param loginUser
-     * @param messageIds 선택한 메세지 ID List
+     * @param requestDto 열매 맺기 요청 DTO
      */
     @ApiOperation(value = "열매 맺기", notes = "메세지 공개 여부 설정")
     @ApiResponses({
@@ -92,11 +93,11 @@ public class MessageController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PutMapping("/api/messages/opening")
     public ResponseEntity<Void> openingMessage(@ApiIgnore @LoginUser LoginUserDto loginUser,
-                                               @RequestBody List<Long> messageIds) {
+                                               @RequestBody @Valid OpeningRequestDto requestDto) {
 
-        log.info("[messageIds] : {}", messageIds);
+        log.info("[messageIds] : {}", requestDto.getMessageIds());
 
-        messageService.updateMessageOpening(loginUser.getId(), messageIds);
+        messageService.updateMessageOpening(loginUser.getId(), requestDto);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/com/yapp/betree/dto/request/OpeningRequestDto.java
+++ b/src/main/java/com/yapp/betree/dto/request/OpeningRequestDto.java
@@ -1,0 +1,26 @@
+package com.yapp.betree.dto.request;
+
+import io.swagger.annotations.ApiModel;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ApiModel(description = "열매맺기 요청 DTO")
+public class OpeningRequestDto {
+
+    @NotNull(message = "열매 맺을 메세지 아이디를 입력해주세요.")
+    private List<Long> messageIds;
+
+    @NotNull(message = "열매 맺을 나무 아이디를 입력해주세요.")
+    private Long treeId;
+
+    @Builder
+    public OpeningRequestDto(List<Long> messageIds, Long treeId) {
+        this.messageIds = messageIds;
+        this.treeId = treeId;
+    }
+}

--- a/src/main/java/com/yapp/betree/repository/MessageRepository.java
+++ b/src/main/java/com/yapp/betree/repository/MessageRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
-    List<Message> findByUserIdAndOpeningAndDelByReceiver(Long userId, boolean opening, boolean delByReceiver);
+    List<Message> findByUserIdAndOpeningAndDelByReceiverAndFolderId(Long userId, boolean opening, boolean delByReceiver, Long folderId);
 
     Slice<Message> findByUserIdAndFolderIdAndDelByReceiver(Long userId, Long treeId, boolean delByReceiver, Pageable pageable);
 

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -6,6 +6,7 @@ import com.yapp.betree.domain.Message;
 import com.yapp.betree.domain.User;
 import com.yapp.betree.dto.SendUserDto;
 import com.yapp.betree.dto.request.MessageRequestDto;
+import com.yapp.betree.dto.request.OpeningRequestDto;
 import com.yapp.betree.dto.response.MessageBoxResponseDto;
 import com.yapp.betree.dto.response.MessageDetailResponseDto;
 import com.yapp.betree.dto.response.MessagePageResponseDto;
@@ -113,19 +114,19 @@ public class MessageService {
      * 선택한 메세지 공개로 설정 (열매 맺기)
      *
      * @param userId
-     * @param messageIds
+     * @param dto
      */
     @Transactional
-    public void updateMessageOpening(Long userId, List<Long> messageIds) {
+    public void updateMessageOpening(Long userId, OpeningRequestDto dto) {
         //선택한 개수 8개 초과면 오류
-        if (messageIds.size() > 8) {
+        if (dto.getMessageIds().size() > 8) {
             throw new BetreeException(ErrorCode.INVALID_INPUT_VALUE, "열매로 맺을 수 있는 메세지 개수는 최대 8개입니다.");
         }
         //이미 선택된 메세지 가져와서 false로 변경
-        messageRepository.findByUserIdAndOpeningAndDelByReceiver(userId, true, false).forEach(Message::updateOpening);
+        messageRepository.findByUserIdAndOpeningAndDelByReceiverAndFolderId(userId, true, false, dto.getTreeId()).forEach(Message::updateOpening);
 
         // 지금 선택된 메세지만 true로 변경
-        for (Long id : messageIds) {
+        for (Long id : dto.getMessageIds()) {
             messageRepository.findById(id).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId = " + id)).updateOpening();
         }
     }

--- a/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
@@ -3,6 +3,7 @@ package com.yapp.betree.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yapp.betree.config.TestConfig;
 import com.yapp.betree.dto.request.MessageRequestDto;
+import com.yapp.betree.dto.request.OpeningRequestDto;
 import com.yapp.betree.dto.response.MessageBoxResponseDto;
 import com.yapp.betree.dto.response.MessagePageResponseDto;
 import com.yapp.betree.exception.BetreeException;
@@ -130,13 +131,14 @@ class MessageControllerTest extends ControllerTest {
     @Test
     void updateMessageOpening() throws Exception {
 
-        List<String> idList = Arrays.asList(String.valueOf(9L), String.valueOf(10L));
+        List<Long> idList = Arrays.asList(9L, 10L);
+        OpeningRequestDto dto = OpeningRequestDto.builder().messageIds(idList).treeId(0L).build();
 
         mockMvc.perform(put("/api/messages/opening")
                 .cookie(TestConfig.COOKIE_TOKEN)
                 .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(idList)))
+                .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }

--- a/src/test/java/com/yapp/betree/service/MessageServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/MessageServiceTest.java
@@ -4,6 +4,7 @@ import com.yapp.betree.domain.FruitType;
 import com.yapp.betree.domain.Message;
 import com.yapp.betree.dto.SendUserDto;
 import com.yapp.betree.dto.request.MessageRequestDto;
+import com.yapp.betree.dto.request.OpeningRequestDto;
 import com.yapp.betree.dto.response.MessagePageResponseDto;
 import com.yapp.betree.exception.BetreeException;
 import com.yapp.betree.exception.ErrorCode;
@@ -98,8 +99,11 @@ public class MessageServiceTest {
     void fruitCountError() {
 
         List<Long> messageIds = Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
+        Long treeId = 0L;
 
-        assertThatThrownBy(() -> messageService.updateMessageOpening(TEST_SAVE_USER.getId(), messageIds))
+        OpeningRequestDto dto = OpeningRequestDto.builder().messageIds(messageIds).treeId(treeId).build();
+
+        assertThatThrownBy(() -> messageService.updateMessageOpening(TEST_SAVE_USER.getId(), dto))
                 .isInstanceOf(BetreeException.class)
                 .hasMessageContaining("Invalid input value")
                 .extracting("code").isEqualTo(ErrorCode.INVALID_INPUT_VALUE);


### PR DESCRIPTION
## 작업 내용
- 열매 맺기시 폴더 선택 없이 모든 메세지 공개 여부를 초기화 시키는 상태 -> 폴더 입력 받아 해당 폴더의 메세지만 설정

## 기타 사항
- 내용을 적어주세요.

## 체크리스트
- [ ] 테스트