### PR TITLE
fix: 즐겨찾기 메세지 상세 조회 api 추가 (같은 서비스 로직 사용)

### DIFF
--- a/src/main/java/com/yapp/betree/controller/MessageController.java
+++ b/src/main/java/com/yapp/betree/controller/MessageController.java
@@ -231,6 +231,26 @@ public class MessageController {
 
         log.info("[메세지 상세 조회] userId: {}, messageId: {}", loginUser.getId(), messageId);
 
-        return ResponseEntity.ok(messageService.getMessageDetail(loginUser.getId(), messageId));
+        return ResponseEntity.ok(messageService.getMessageDetail(loginUser.getId(), messageId, false));
+    }
+
+    /**
+     * 즐겨찾기한 메세지 상세 조회
+     *
+     * @param loginUser
+     * @return
+     */
+    @ApiOperation(value = "즐겨찾기 메세지 상세 조회", notes = "즐겨찾기한 메세지 상세 조회")
+    @ApiResponses({
+            @ApiResponse(code = 404, message = "[M001]메세지가 존재하지 않습니다.\n" +
+                    "[U005]회원을 찾을 수 없습니다. (보낸 유저가 존재하지 않음)")
+    })
+    @GetMapping("/api/messages/favorite/{messageId}")
+    public ResponseEntity<MessageDetailResponseDto> getFavoriteMessageDetail(@ApiIgnore @LoginUser LoginUserDto loginUser,
+                                                                             @PathVariable Long messageId) {
+
+        log.info("[메세지 상세 조회] userId: {}, messageId: {}", loginUser.getId(), messageId);
+
+        return ResponseEntity.ok(messageService.getMessageDetail(loginUser.getId(), messageId, true));
     }
 }

--- a/src/main/java/com/yapp/betree/service/MessageService.java
+++ b/src/main/java/com/yapp/betree/service/MessageService.java
@@ -235,7 +235,7 @@ public class MessageService {
      * @param messageId
      * @return
      */
-    public MessageDetailResponseDto getMessageDetail(Long userId, Long messageId) {
+    public MessageDetailResponseDto getMessageDetail(Long userId, Long messageId, boolean favorite) {
 
         Message message = messageRepository.findByIdAndUserIdAndDelByReceiver(messageId, userId, false).orElseThrow(() -> new BetreeException(MESSAGE_NOT_FOUND, "messageId =" + messageId));
 
@@ -246,7 +246,7 @@ public class MessageService {
         Long prevId;
         Long nextId;
         // 즐겨찾기 메세지는 즐겨찾기 메세지끼리 이전, 다음 메세지 보여주기
-        if (message.isFavorite()) {
+        if (favorite) {
             prevId = messageRepository.findTop1ByUserIdAndFavoriteAndDelByReceiverAndIdLessThanOrderByIdDesc(userId, true, false, message.getId())
                     .map(Message::getId)
                     .orElse(0L);

--- a/src/test/java/com/yapp/betree/controller/MessageAcceptanceTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageAcceptanceTest.java
@@ -216,7 +216,7 @@ public class MessageAcceptanceTest {
         given(jwtTokenProvider.parseToken(token)).willReturn(getClaims(user.getId()));
 
         // 즐겨찾기 이전, 다음 메세지 조회
-        mockMvc.perform(get("/api/messages/" + message3.getId())
+        mockMvc.perform(get("/api/messages/favorite/" + message3.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .cookie(TestConfig.COOKIE_TOKEN)
                         .header("Authorization", "Bearer " + token))

--- a/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/MessageControllerTest.java
@@ -220,7 +220,7 @@ class MessageControllerTest extends ControllerTest {
     @Test
     void getMessageDetail() throws Exception {
 
-        given(messageService.getMessageDetail(anyLong(),eq(1L))).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
+        given(messageService.getMessageDetail(anyLong(), eq(1L), eq(false))).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
 
         mockMvc.perform(get("/api/messages/1")
                         .cookie(TestConfig.COOKIE_TOKEN)

--- a/src/test/java/com/yapp/betree/service/MessageServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/MessageServiceTest.java
@@ -181,7 +181,7 @@ public class MessageServiceTest {
 
         given(messageRepository.findByIdAndUserIdAndDelByReceiver(10L, TEST_SAVE_USER.getId(), false)).willThrow(new BetreeException(ErrorCode.MESSAGE_NOT_FOUND));
 
-        assertThatThrownBy(() -> messageService.getMessageDetail(TEST_SAVE_USER.getId(), 10L))
+        assertThatThrownBy(() -> messageService.getMessageDetail(TEST_SAVE_USER.getId(), 10L, false))
                 .isInstanceOf(BetreeException.class)
                 .hasMessageContaining("메세지가 존재하지 않습니다.")
                 .extracting("code").isEqualTo(ErrorCode.MESSAGE_NOT_FOUND);


### PR DESCRIPTION
## 이슈
- #108 

## 작업 내용
- 프론트와 api 협의 내용 
    - 폴더 별 메세지 상세 조회 : api/messages/{messageId}
    - 즐겨찾기 탭의 즐겨찾기 메세지 상세 조회 : api/messages/favorite/{messageId}
 - 기존의 상세 조회 비즈니스 로직에 boolean 값만 추가해서 구별하도록 했습니다.
 - api가 나뉘어서 로직도 따로 빼는게 좋을 것 같다거나 더 간단한 방법 있으면 말씀해주세요

## 체크리스트
- [ ] 테스트