### PR TITLE
fix: 로컬 개발용 리프레시토큰검증 제외 로직 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,11 +40,6 @@ jobs:
         spring.datasource.url: ${{ secrets.RDS_URL }}
         spring.datasource.username: ${{ secrets.RDS_USER_NAME }}
         spring.datasource.password: ${{ secrets.RDS_PASSWORD }}
-        dev.email.js: ${{ secrets.EMAIL_JS }}
-        dev.email.sb: ${{ secrets.EMAIL_SB }}
-        dev.email.si: ${{ secrets.EMAIL_SI }}
-        dev.email.yk: ${{ secrets.EMAIL_YK }}
-        dev.email.ym: ${{ secrets.EMAIL_YM }}
 
     - name: Grant execute permission for gradlew
       run: chmod +x ./gradlew

--- a/src/main/java/com/yapp/betree/interceptor/TokenInterceptor.java
+++ b/src/main/java/com/yapp/betree/interceptor/TokenInterceptor.java
@@ -23,17 +23,6 @@ import java.util.Optional;
 @Slf4j
 public class TokenInterceptor implements HandlerInterceptor {
 
-    @Value("dev.email.js")
-    private String jisu;
-    @Value("dev.email.sb")
-    private String subin;
-    @Value("dev.email.si")
-    private String sooim;
-    @Value("dev.email.ym")
-    private String ym;
-    @Value("dev.email.yk")
-    private String yk;
-
     private static final String AUTH_TYPE = "Bearer";
     public static final String USER_ATTR_KEY = "user";
     public static final int ZERO = 0;
@@ -100,25 +89,6 @@ public class TokenInterceptor implements HandlerInterceptor {
         String forward = request.getHeader("X-Forwarded-For");
         String proto = request.getHeader("X-Forwarded-Proto");
         log.info("[요청 유저 정보] ip:{}, forward:{}, proto:{}", ip, forward, proto);
-    }
-
-    private boolean isFrontEndLocal(String authHeader) {
-        // FE, BE 개발자들 로그인할때는 토큰검증 임시로 예외처리->로컬개발 가능하게 하려고
-        List<String> devEmails = new ArrayList<>();
-        devEmails.add(jisu);
-        devEmails.add(subin);
-        devEmails.add(yk);
-        devEmails.add(ym);
-        devEmails.add(sooim);
-
-        authHeader = authHeader.substring(AUTH_TYPE.length()).trim();
-        Claims claims = jwtTokenProvider.parseToken(authHeader);
-        if (Objects.isNull(claims)) {
-            throw new BetreeException(ErrorCode.USER_TOKEN_ERROR, "토큰의 payload는 null일 수 없습니다.");
-        }
-
-        log.info("[개발자 로그인] info : {}", claims.get("email"));
-        return devEmails.contains(claims.get("email"));
     }
 
     private boolean isInvalidRefreshToken(Cookie[] cookies) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,11 +47,3 @@ secrets:
       secret-key: B1e2t3r4e5e6S7e8c9r0e1t
       expiration-time: 86400000
       refresh-expiration-time: 86400000
-
-dev:
-  email:
-    js: default
-    sb: default
-    si: default
-    yk: default
-    ym: default


### PR DESCRIPTION
## 이슈
- 로컬에도 쿠키설정, 리프레시토큰 처리 되고있는 것 같아서 임시로 개발자용 검증통과메서드 만들었던거 삭제하겠습니다

## 작업 내용
- 안쓰이는부분 제거

## 기타 사항
- 내용을 적어주세요.

## 체크리스트
- [ ] example