### PR TITLE
fix: 나무숲 조회시 해당 유저 닉네임 반환 (프론트 요청)

### DIFF
--- a/src/main/java/com/yapp/betree/controller/ForestController.java
+++ b/src/main/java/com/yapp/betree/controller/ForestController.java
@@ -4,8 +4,8 @@ import com.yapp.betree.annotation.LoginUser;
 import com.yapp.betree.domain.FruitType;
 import com.yapp.betree.dto.LoginUserDto;
 import com.yapp.betree.dto.request.TreeRequestDto;
+import com.yapp.betree.dto.response.ForestResponseDto;
 import com.yapp.betree.dto.response.TreeFullResponseDto;
-import com.yapp.betree.dto.response.TreeResponseDto;
 import com.yapp.betree.exception.BetreeException;
 import com.yapp.betree.exception.ErrorCode;
 import com.yapp.betree.service.FolderService;
@@ -30,7 +30,6 @@ import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
-import java.util.List;
 
 @Api
 @RestController
@@ -52,8 +51,8 @@ public class ForestController {
             @ApiResponse(code = 404, message = "[U005]회원을 찾을 수 없습니다.")
     })
     @GetMapping("/api/forest")
-    public ResponseEntity<List<TreeResponseDto>> userForest(@ApiIgnore @LoginUser LoginUserDto loginUser,
-                                                            @RequestParam Long userId) {
+    public ResponseEntity<ForestResponseDto> userForest(@ApiIgnore @LoginUser LoginUserDto loginUser,
+                                                        @RequestParam Long userId) {
         log.info("[나무숲] 유저 나무숲 조회 userId: {}, loginUserId: {}", userId, loginUser.getId());
         if (!userService.isExist(userId)) {
             throw new BetreeException(ErrorCode.USER_NOT_FOUND, "userId = " + userId);

--- a/src/main/java/com/yapp/betree/dto/response/ForestResponseDto.java
+++ b/src/main/java/com/yapp/betree/dto/response/ForestResponseDto.java
@@ -1,0 +1,20 @@
+package com.yapp.betree.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ForestResponseDto {
+
+    private String nickname;
+    List<TreeResponseDto> responseDtoList;
+
+    @Builder
+    public ForestResponseDto(String nickname, List<TreeResponseDto> responseDtoList) {
+        this.nickname = nickname;
+        this.responseDtoList = responseDtoList;
+    }
+}

--- a/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
+++ b/src/test/java/com/yapp/betree/controller/ForestControllerTest.java
@@ -5,6 +5,7 @@ import com.yapp.betree.config.TestConfig;
 import com.yapp.betree.domain.FruitType;
 import com.yapp.betree.domain.MessageTest;
 import com.yapp.betree.dto.SendUserDto;
+import com.yapp.betree.dto.response.ForestResponseDto;
 import com.yapp.betree.dto.response.MessageResponseDto;
 import com.yapp.betree.dto.response.TreeFullResponseDto;
 import com.yapp.betree.dto.response.TreeResponseDto;
@@ -76,8 +77,13 @@ public class ForestControllerTest extends ControllerTest {
     @Test
     void userForestTest() throws Exception {
         Long userId = 1L;
+
+        ForestResponseDto dto = ForestResponseDto.builder()
+                .nickname(TEST_SAVE_USER.getNickname())
+                .responseDtoList(Lists.newArrayList(TreeResponseDto.of(TEST_SAVE_DEFAULT_TREE))).build();
+
         given(userService.isExist(userId)).willReturn(true);
-        given(folderService.userForest(userId, userId)).willReturn(Lists.newArrayList(TreeResponseDto.of(TEST_SAVE_DEFAULT_TREE)));
+        given(folderService.userForest(userId, userId)).willReturn(dto);
 
         mockMvc.perform(get("/api/forest")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -85,7 +91,7 @@ public class ForestControllerTest extends ControllerTest {
                         .header("Authorization", "Bearer " + JwtTokenTest.JWT_TOKEN_TEST)
                         .param("userId", String.valueOf(userId)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").value(TEST_SAVE_DEFAULT_TREE.getId()))
+                .andExpect(jsonPath("$.responseDtoList[0].id").value(TEST_SAVE_DEFAULT_TREE.getId()))
                 .andDo(print());
     }
 
@@ -94,7 +100,7 @@ public class ForestControllerTest extends ControllerTest {
     void otherUserForestTest() throws Exception {
         Long userId = 2L;
         given(userService.isExist(userId)).willReturn(true);
-        given(folderService.userForest(userId, userId)).willReturn(Lists.emptyList());
+        given(folderService.userForest(userId, userId)).willReturn(any());
 
         mockMvc.perform(get("/api/forest")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/yapp/betree/service/FolderServiceTest.java
+++ b/src/test/java/com/yapp/betree/service/FolderServiceTest.java
@@ -6,6 +6,7 @@ import com.yapp.betree.domain.Message;
 import com.yapp.betree.domain.User;
 import com.yapp.betree.dto.SendUserDto;
 import com.yapp.betree.dto.request.TreeRequestDto;
+import com.yapp.betree.dto.response.ForestResponseDto;
 import com.yapp.betree.dto.response.MessageResponseDto;
 import com.yapp.betree.dto.response.TreeFullResponseDto;
 import com.yapp.betree.dto.response.TreeResponseDto;
@@ -57,12 +58,13 @@ public class FolderServiceTest {
     void userForestTest() {
         // given
         given(folderRepository.findAllByUserId(USER_ID)).willReturn(Lists.newArrayList(TEST_SAVE_APPLE_TREE, TEST_SAVE_DEFAULT_TREE));
+        given(userService.findById(USER_ID)).willReturn(Optional.ofNullable(TEST_SAVE_USER));
 
         // when
-        List<TreeResponseDto> treeResponseDtos = folderService.userForest(USER_ID, USER_ID);
+        ForestResponseDto forestResponseDto = folderService.userForest(USER_ID, USER_ID);
 
         // then
-        assertThat(treeResponseDtos).contains(TreeResponseDto.of(TEST_SAVE_APPLE_TREE));
+        assertThat(forestResponseDto.getResponseDtoList()).contains(TreeResponseDto.of(TEST_SAVE_APPLE_TREE));
     }
 
     @Test
@@ -70,12 +72,13 @@ public class FolderServiceTest {
     void otherUserForestTest() {
         // given
         given(folderRepository.findAllByUserId(USER_ID)).willReturn(Lists.newArrayList(TEST_SAVE_APPLE_TREE));
+        given(userService.findById(USER_ID)).willReturn(Optional.ofNullable(TEST_SAVE_USER));
 
         // when
-        List<TreeResponseDto> treeResponseDtos = folderService.userForest(-1L, USER_ID);
+        ForestResponseDto forestResponseDto = folderService.userForest(-1L, USER_ID);
 
         // then
-        assertThat(treeResponseDtos).contains(TreeResponseDto.of(TEST_SAVE_APPLE_TREE));
+        assertThat(forestResponseDto.getResponseDtoList()).contains(TreeResponseDto.of(TEST_SAVE_APPLE_TREE));
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
- 공유 url 접속 후 나무 숲 조회 시 해당 유저 닉네임이 있어야 물주기시 ~에게 표기 가능

## 기타 사항
- 내용을 적어주세요.

## 체크리스트
- [x] 테스트